### PR TITLE
Add Sylvia helpers

### DIFF
--- a/packages/apis/src/cross_staking_api.rs
+++ b/packages/apis/src/cross_staking_api.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Addr, Binary, Coin, Deps, Response, StdError, Uint128, WasmMsg};
 use sylvia::types::{ExecCtx, QueryCtx};
@@ -36,14 +34,6 @@ pub trait CrossStakingApi {
 
 #[cw_serde]
 pub struct CrossStakingApiHelper(pub Addr);
-
-impl Deref for CrossStakingApiHelper {
-    type Target = Addr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl CrossStakingApiHelper {
     pub fn addr(&self) -> &Addr {

--- a/packages/apis/src/cross_staking_api.rs
+++ b/packages/apis/src/cross_staking_api.rs
@@ -1,4 +1,7 @@
-use cosmwasm_std::{Binary, Response, StdError, Uint128};
+use std::ops::Deref;
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{to_binary, Addr, Binary, Coin, Deps, Response, StdError, Uint128, WasmMsg};
 use sylvia::types::{ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
@@ -29,4 +32,42 @@ pub trait CrossStakingApi {
     /// Returns the maximum percentage that can be slashed
     #[msg(query)]
     fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error>;
+}
+
+#[cw_serde]
+pub struct CrossStakingApiHelper(pub Addr);
+
+impl Deref for CrossStakingApiHelper {
+    type Target = Addr;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl CrossStakingApiHelper {
+    pub fn addr(&self) -> &Addr {
+        &self.0
+    }
+
+    pub fn receive_virtual_stake(
+        &self,
+        owner: String,
+        amount: Uint128,
+        msg: Binary,
+        funds: Vec<Coin>,
+    ) -> Result<WasmMsg, StdError> {
+        let msg = CrossStakingApiExecMsg::ReceiveVirtualStake { owner, msg, amount };
+        let wasm = WasmMsg::Execute {
+            contract_addr: self.0.to_string(),
+            msg: to_binary(&msg)?,
+            funds,
+        };
+        Ok(wasm)
+    }
+
+    pub fn max_slash(&self, deps: Deps) -> Result<MaxSlashResponse, StdError> {
+        let query = CrossStakingApiQueryMsg::MaxSlash {};
+        deps.querier.query_wasm_smart(&self.0, &query)
+    }
 }

--- a/packages/apis/src/local_staking_api.rs
+++ b/packages/apis/src/local_staking_api.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Addr, Binary, Coin, Decimal, Deps, Response, StdError, WasmMsg};
-use std::ops::Deref;
 use sylvia::types::{ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
@@ -38,14 +37,6 @@ pub trait LocalStakingApi {
 
 #[cw_serde]
 pub struct LocalStakingApiHelper(pub Addr);
-
-impl Deref for LocalStakingApiHelper {
-    type Target = Addr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl LocalStakingApiHelper {
     pub fn addr(&self) -> &Addr {

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{Response, StdError, Uint128};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{to_binary, Addr, Coin, Response, StdError, Uint128, WasmMsg};
+use std::ops::Deref;
 use sylvia::types::ExecCtx;
 use sylvia::{interface, schemars};
 
@@ -28,4 +30,53 @@ pub trait VaultApi {
         // address of the user who originally called stake_remote
         owner: String,
     ) -> Result<Response, Self::Error>;
+}
+
+#[cw_serde]
+pub struct VaultApiHelper(pub Addr);
+
+impl Deref for VaultApiHelper {
+    type Target = Addr;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl VaultApiHelper {
+    pub fn addr(&self) -> &Addr {
+        &self.0
+    }
+
+    pub fn release_cross_stake(
+        &self,
+        // address of the user who originally called stake_remote
+        owner: String,
+        // amount to unstake on that contract
+        amount: Uint128,
+    ) -> Result<WasmMsg, StdError> {
+        let msg = VaultApiExecMsg::ReleaseCrossStake { owner, amount };
+        let wasm = WasmMsg::Execute {
+            contract_addr: self.0.to_string(),
+            msg: to_binary(&msg)?,
+            funds: vec![],
+        };
+        Ok(wasm)
+    }
+
+    pub fn release_local_stake(
+        &self,
+        // address of the user who originally called stake_remote
+        owner: String,
+        // tokens to send along with this
+        funds: Coin,
+    ) -> Result<WasmMsg, StdError> {
+        let msg = VaultApiExecMsg::ReleaseLocalStake { owner };
+        let wasm = WasmMsg::Execute {
+            contract_addr: self.0.to_string(),
+            msg: to_binary(&msg)?,
+            funds: vec![funds],
+        };
+        Ok(wasm)
+    }
 }

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Addr, Coin, Response, StdError, Uint128, WasmMsg};
-use std::ops::Deref;
 use sylvia::types::ExecCtx;
 use sylvia::{interface, schemars};
 
@@ -34,14 +33,6 @@ pub trait VaultApi {
 
 #[cw_serde]
 pub struct VaultApiHelper(pub Addr);
-
-impl Deref for VaultApiHelper {
-    type Target = Addr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl VaultApiHelper {
     pub fn addr(&self) -> &Addr {

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -54,12 +54,13 @@ impl VaultApiHelper {
         owner: String,
         // amount to unstake on that contract
         amount: Uint128,
+        funds: Vec<Coin>,
     ) -> Result<WasmMsg, StdError> {
         let msg = VaultApiExecMsg::ReleaseCrossStake { owner, amount };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
             msg: to_binary(&msg)?,
-            funds: vec![],
+            funds,
         };
         Ok(wasm)
     }
@@ -69,13 +70,13 @@ impl VaultApiHelper {
         // address of the user who originally called stake_remote
         owner: String,
         // tokens to send along with this
-        funds: Coin,
+        funds: Vec<Coin>,
     ) -> Result<WasmMsg, StdError> {
         let msg = VaultApiExecMsg::ReleaseLocalStake { owner };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
             msg: to_binary(&msg)?,
-            funds: vec![funds],
+            funds,
         };
         Ok(wasm)
     }

--- a/packages/mocks/src/cross_staking.rs
+++ b/packages/mocks/src/cross_staking.rs
@@ -67,7 +67,7 @@ impl MockCrossStakingContract<'_> {
         let cfg = self.config.load(ctx.deps.storage)?;
         let wasm = cfg
             .vault
-            .release_cross_stake(ctx.info.sender.into_string(), amount)?;
+            .release_cross_stake(ctx.info.sender.into_string(), amount, vec![])?;
         Ok(Response::new().add_message(wasm))
     }
 }

--- a/packages/mocks/src/cross_staking.rs
+++ b/packages/mocks/src/cross_staking.rs
@@ -3,14 +3,12 @@ use sylvia::{contract, schemars};
 use thiserror::Error;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{
-    ensure_eq, to_binary, Addr, Binary, Decimal, Response, StdError, Uint128, WasmMsg,
-};
+use cosmwasm_std::{ensure_eq, Binary, Decimal, Response, StdError, Uint128};
 use cw_storage_plus::Item;
 use cw_utils::{nonpayable, PaymentError};
 
 use mesh_apis::cross_staking_api::{self, CrossStakingApi, MaxSlashResponse};
-use mesh_apis::vault_api::VaultApiExecMsg;
+use mesh_apis::vault_api::VaultApiHelper;
 
 #[derive(Error, Debug)]
 pub enum StakingError {
@@ -27,7 +25,7 @@ pub enum StakingError {
 #[cw_serde]
 pub struct Config {
     /// The address of the vault contract (where we get and return stake)
-    pub vault: Addr,
+    pub vault: VaultApiHelper,
 
     pub max_slash: Decimal,
 }
@@ -54,7 +52,7 @@ impl MockCrossStakingContract<'_> {
         vault: String,
     ) -> Result<Response, StakingError> {
         let config = Config {
-            vault: ctx.deps.api.addr_validate(&vault)?,
+            vault: VaultApiHelper(ctx.deps.api.addr_validate(&vault)?),
             max_slash,
         };
         self.config.save(ctx.deps.storage, &config)?;
@@ -67,15 +65,9 @@ impl MockCrossStakingContract<'_> {
 
         // blindly reduce lien on vault
         let cfg = self.config.load(ctx.deps.storage)?;
-        let msg = VaultApiExecMsg::ReleaseCrossStake {
-            owner: ctx.info.sender.into_string(),
-            amount,
-        };
-        let wasm = WasmMsg::Execute {
-            contract_addr: cfg.vault.into_string(),
-            msg: to_binary(&msg)?,
-            funds: vec![],
-        };
+        let wasm = cfg
+            .vault
+            .release_cross_stake(ctx.info.sender.into_string(), amount)?;
         Ok(Response::new().add_message(wasm))
     }
 }
@@ -99,7 +91,11 @@ impl CrossStakingApi for MockCrossStakingContract<'_> {
 
         // only can be called by the vault
         let cfg = self.config.load(ctx.deps.storage)?;
-        ensure_eq!(cfg.vault, ctx.info.sender, StakingError::Unauthorized {});
+        ensure_eq!(
+            cfg.vault.addr(),
+            &ctx.info.sender,
+            StakingError::Unauthorized {}
+        );
 
         // ignore args
         let _ = (owner, msg, amount);

--- a/packages/mocks/src/local_staking.rs
+++ b/packages/mocks/src/local_staking.rs
@@ -75,7 +75,7 @@ impl MockLocalStakingContract<'_> {
         };
         let wasm = cfg
             .vault
-            .release_local_stake(ctx.info.sender.into_string(), funds)?;
+            .release_local_stake(ctx.info.sender.into_string(), vec![funds])?;
         Ok(Response::new().add_message(wasm))
     }
 }


### PR DESCRIPTION
Add some helper classes to call `#[interface]` traits (struct that wraps execute and query methods to use in cross-contract calls).

This is written by hand now to simplify the coding in the contracts (which will be repeated in mocks and real contracts). But ideally this could be autogenerated in a future sylvia release.

I added `funds: Vec<Coin>` as an extra arg to all execute methods (even ones that don't need funds) to simulate the API that would be generated by sylvia codegen. But it is already usable as is.