### PR TITLE
Various fixes to Virtual Staking contract

### DIFF
--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -8,7 +8,9 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
 use cw_utils::nonpayable;
-use mesh_bindings::{TokenQuerier, VirtualStakeCustomMsg, VirtualStakeCustomQuery};
+use mesh_bindings::{
+    TokenQuerier, VirtualStakeCustomMsg, VirtualStakeCustomQuery, VirtualStakeMsg,
+};
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
 use sylvia::{contract, schemars};
 
@@ -149,12 +151,12 @@ fn calculate_rebalance(
             Ordering::Less => {
                 let unbond = prev - next;
                 let amount = coin(unbond.u128(), denom);
-                msgs.push(StakingMsg::Undelegate { validator, amount }.into())
+                msgs.push(VirtualStakeMsg::Unbond { validator, amount }.into())
             }
             Ordering::Greater => {
                 let bond = next - prev;
                 let amount = coin(bond.u128(), denom);
-                msgs.push(StakingMsg::Delegate { validator, amount }.into())
+                msgs.push(VirtualStakeMsg::Bond { validator, amount }.into())
             }
             Ordering::Equal => {}
         }

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -165,7 +165,7 @@ fn calculate_rebalance(
     // any new validators in the desired list need to be bonded
     for (validator, bond) in desired {
         let amount = coin(bond.u128(), denom);
-        msgs.push(StakingMsg::Delegate { validator, amount }.into())
+        msgs.push(VirtualStakeMsg::Bond { validator, amount }.into())
     }
 
     msgs

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -2,8 +2,8 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use cosmwasm_std::{
-    coin, ensure_eq, entry_point, Coin, CosmosMsg, DepsMut, DistributionMsg, Env, Response,
-    StakingMsg, SubMsg, Uint128,
+    coin, ensure_eq, entry_point, Coin, CosmosMsg, DepsMut, DistributionMsg, Env, Response, SubMsg,
+    Uint128,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use cosmwasm_std::{
     coin, ensure_eq, entry_point, Coin, CosmosMsg, DepsMut, DistributionMsg, Env, Response,
@@ -139,7 +139,7 @@ fn calculate_rebalance(
     desired: Vec<(String, Uint128)>,
     denom: &str,
 ) -> Vec<CosmosMsg<VirtualStakeCustomMsg>> {
-    let mut desired: HashMap<_, _> = desired.into_iter().collect();
+    let mut desired: BTreeMap<_, _> = desired.into_iter().collect();
 
     // this will handle adjustments to all current validators
     let mut msgs = vec![];


### PR DESCRIPTION
Virtual staking is being tested in system tests.

Errored on "Not Found" due to uninitialized Items.
This fixes two cases this could occur.

Also, use BTreeMap not HashMap due to consistency concerns

Finally, use the `VirtualStakingMsg::{Bond, Unbond}` messages rather than `StakingMsg::{Delegate, Undelegate}`

This is being tested in https://github.com/osmosis-labs/mesh-security-sdk/pull/22