### PR TITLE
External staking rewards distribution

### DIFF
--- a/contracts/external-staking/src/contract.rs
+++ b/contracts/external-staking/src/contract.rs
@@ -1,9 +1,12 @@
+use std::cmp::Ordering;
+
 use cosmwasm_std::{
-    coin, ensure, ensure_eq, from_binary, Addr, Binary, Coin, Decimal, Order, Response, StdResult,
-    Uint128,
+    coin, coins, ensure, ensure_eq, from_binary, Addr, BankMsg, Binary, Coin, Decimal, Order,
+    Response, StdResult, Uint128, Uint256,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Bounder, Item, Map};
+use cw_utils::must_pay;
 use mesh_apis::cross_staking_api::{self, CrossStakingApi};
 use mesh_apis::local_staking_api::MaxSlashResponse;
 use mesh_apis::vault_api::VaultApiHelper;
@@ -12,14 +15,16 @@ use sylvia::contract;
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
 
 use crate::error::ContractError;
-use crate::msg::{ConfigResponse, ReceiveVirtualStake, StakeInfo, StakesResponse};
-use crate::state::{Config, PendingUnbond, Stake};
+use crate::msg::{ConfigResponse, PendingRewards, ReceiveVirtualStake, StakeInfo, StakesResponse};
+use crate::state::{Config, Distribution, PendingUnbond, Stake};
 
 pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const DEFAULT_PAGE_LIMIT: u32 = 10;
 pub const MAX_PAGE_LIMIT: u32 = 30;
+
+pub const DISTRIBUTION_POINTS_SCALE: Uint256 = Uint256::from_u128(1_000_000_000);
 
 /// Aligns pagination limit
 fn clamp_page_limit(limit: Option<u32>) -> usize {
@@ -30,6 +35,8 @@ pub struct ExternalStakingContract<'a> {
     pub config: Item<'a, Config>,
     // Stakes indexed by `(owner, validator)` pair
     pub stakes: Map<'a, (&'a Addr, &'a str), Stake>,
+    // Per-validator distribution information
+    pub distribution: Map<'a, &'a str, Distribution>,
 }
 
 #[cfg_attr(not(feature = "library"), sylvia::entry_points)]
@@ -41,6 +48,7 @@ impl ExternalStakingContract<'_> {
         Self {
             config: Item::new("config"),
             stakes: Map::new("stakes"),
+            distribution: Map::new("distribution"),
         }
     }
 
@@ -49,6 +57,7 @@ impl ExternalStakingContract<'_> {
         &self,
         ctx: InstantiateCtx,
         denom: String,
+        rewards_denom: String,
         vault: String,
         unbonding_period: u64,
     ) -> Result<Response, ContractError> {
@@ -57,6 +66,7 @@ impl ExternalStakingContract<'_> {
 
         let config = Config {
             denom,
+            rewards_denom,
             vault,
             unbonding_period,
         };
@@ -90,6 +100,8 @@ impl ExternalStakingContract<'_> {
             .may_load(ctx.deps.storage, (&ctx.info.sender, &validator))?
             .unwrap_or_default();
 
+        let mut distribution = self.distribution.load(ctx.deps.storage, &validator)?;
+
         ensure!(
             stake.stake >= amount.amount,
             ContractError::NotEnoughStake(stake.stake)
@@ -104,8 +116,15 @@ impl ExternalStakingContract<'_> {
         };
         stake.pending_unbonds.push(unbond);
 
+        // Distribution alignment
+        stake.points_alignment += Uint256::from(amount.amount) * distribution.points_per_stake;
+        distribution.total_stake -= amount.amount;
+
         self.stakes
             .save(ctx.deps.storage, (&ctx.info.sender, &validator), &stake)?;
+
+        self.distribution
+            .save(ctx.deps.storage, &validator, &distribution)?;
 
         // TODO:
         //
@@ -163,6 +182,85 @@ impl ExternalStakingContract<'_> {
             )?;
 
             resp = resp.add_message(release_msg);
+        }
+
+        Ok(resp)
+    }
+
+    /// Distributes reward among users staking via particular validator. Distribution is performend
+    /// proportionally to amount of tokens staken by user.
+    #[msg(exec)]
+    pub fn distribute_rewards(
+        &self,
+        ctx: ExecCtx,
+        validator: String,
+    ) -> Result<Response, ContractError> {
+        let config = self.config.load(ctx.deps.storage)?;
+        let amount = must_pay(&ctx.info, &config.rewards_denom)?;
+
+        let mut distribution = self
+            .distribution
+            .may_load(ctx.deps.storage, &validator)?
+            .unwrap_or_default();
+
+        let total_stake = Uint256::from(distribution.total_stake);
+        let points_distributed =
+            Uint256::from(amount) * DISTRIBUTION_POINTS_SCALE + distribution.points_leftover;
+        let points_per_stake = points_distributed / total_stake;
+
+        distribution.points_leftover = points_distributed - points_per_stake * total_stake;
+        distribution.points_per_stake += points_per_stake;
+
+        self.distribution
+            .save(ctx.deps.storage, &validator, &distribution)?;
+
+        let resp = Response::new()
+            .add_attribute("action", "distribute_rewards")
+            .add_attribute("sender", ctx.info.sender.into_string())
+            .add_attribute("validator", validator)
+            .add_attribute("amount", amount.to_string());
+
+        Ok(resp)
+    }
+
+    /// Withdraw rewards from staking via given validator
+    #[msg(exec)]
+    pub fn withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        validator: String,
+    ) -> Result<Response, ContractError> {
+        let mut stake = self
+            .stakes
+            .may_load(ctx.deps.storage, (&ctx.info.sender, &validator))?
+            .unwrap_or_default();
+
+        let distribution = self
+            .distribution
+            .may_load(ctx.deps.storage, &validator)?
+            .unwrap_or_default();
+
+        let amount = Self::calculate_reward(&stake, &distribution)?;
+
+        let mut resp = Response::new()
+            .add_attribute("action", "withdraw_rewards")
+            .add_attribute("owner", ctx.info.sender.to_string())
+            .add_attribute("validator", &validator)
+            .add_attribute("amount", amount.to_string());
+
+        if !amount.is_zero() {
+            stake.withdrawn_funds += amount;
+
+            self.stakes
+                .save(ctx.deps.storage, (&ctx.info.sender, &validator), &stake)?;
+
+            let config = self.config.load(ctx.deps.storage)?;
+            let send_msg = BankMsg::Send {
+                to_address: ctx.info.sender.into_string(),
+                amount: coins(amount.u128(), config.rewards_denom),
+            };
+
+            resp = resp.add_message(send_msg);
         }
 
         Ok(resp)
@@ -227,6 +325,73 @@ impl ExternalStakingContract<'_> {
 
         Ok(resp)
     }
+
+    /// Returns how much rewards are to be withdrawn by particular user, from the particular
+    /// validator staking
+    #[msg(query)]
+    pub fn pending_rewards(
+        &self,
+        ctx: QueryCtx,
+        user: String,
+        validator: String,
+    ) -> Result<PendingRewards, ContractError> {
+        let user = ctx.deps.api.addr_validate(&user)?;
+
+        let stake = self
+            .stakes
+            .may_load(ctx.deps.storage, (&user, &validator))?
+            .unwrap_or_default();
+
+        let distribution = self
+            .distribution
+            .may_load(ctx.deps.storage, &validator)?
+            .unwrap_or_default();
+
+        let amount = Self::calculate_reward(&stake, &distribution)?;
+        let config = self.config.load(ctx.deps.storage)?;
+
+        let resp = PendingRewards {
+            amount: coin(amount.u128(), &config.rewards_denom),
+        };
+
+        Ok(resp)
+    }
+
+    /// Calculates reward for the user basing on the `Stake` he want to withdraw rewards from, and
+    /// the corresponding validator `Distribution`.
+    //
+    // It is important to make sure the distribution passed matches the validator for stake. It
+    // could be enforced by taking user and validator in arguments, then fetching data, but
+    // sometimes data are used also for different calculations so we want to avoid double
+    // fetching.
+    fn calculate_reward(
+        stake: &Stake,
+        distribution: &Distribution,
+    ) -> Result<Uint128, ContractError> {
+        let points = distribution.points_per_stake * Uint256::from(stake.stake);
+
+        // Points alignment application - way very much around because of offset of `Uint256` we
+        // used
+        let points = match stake
+            .points_alignment
+            .cmp(&(Uint256::MAX / Uint256::from_u128(2)))
+        {
+            // Points alignemnt negative - first we need to add alignment and then add offset
+            // to avoid exceeding limit
+            Ordering::Less => {
+                points + stake.points_alignment - Uint256::MAX / Uint256::from_u128(2)
+            }
+            // Points alignment is positive - first we reduce it by offset and then add to the
+            // poits
+            Ordering::Greater => {
+                points + (stake.points_alignment - Uint256::MAX / Uint256::from_u128(2))
+            }
+            // Alignment is `0`, no math to be done
+            Ordering::Equal => points,
+        };
+
+        Uint128::try_from(points / DISTRIBUTION_POINTS_SCALE).map_err(Into::into)
+    }
 }
 
 pub mod cross_staking {
@@ -257,17 +422,27 @@ pub mod cross_staking {
             let owner = ctx.deps.api.addr_validate(&owner)?;
 
             let msg: ReceiveVirtualStake = from_binary(&msg)?;
-
-            // For now we assume there is only single validator per user, however we want to maintain
-            // proper structure keeping `(user, validator)` as bound index
-
             let mut stake = self
                 .stakes
                 .may_load(ctx.deps.storage, (&owner, &msg.validator))?
                 .unwrap_or_default();
+
+            let mut distribution = self
+                .distribution
+                .may_load(ctx.deps.storage, &msg.validator)?
+                .unwrap_or_default();
+
             stake.stake += amount.amount;
+
+            // Distribution alignment
+            stake.points_alignment -= Uint256::from(amount.amount) * distribution.points_per_stake;
+            distribution.total_stake += amount.amount;
+
             self.stakes
                 .save(ctx.deps.storage, (&owner, &msg.validator), &stake)?;
+
+            self.distribution
+                .save(ctx.deps.storage, &msg.validator, &distribution)?;
 
             // TODO: Send proper IBC message to remote staking contract
 

--- a/contracts/external-staking/src/error.rs
+++ b/contracts/external-staking/src/error.rs
@@ -1,10 +1,17 @@
-use cosmwasm_std::{StdError, Uint128};
+use cosmwasm_std::{ConversionOverflowError, StdError, Uint128};
+use cw_utils::PaymentError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
+
+    #[error("{0}")]
+    Conversion(#[from] ConversionOverflowError),
 
     #[error("Unauthorized")]
     Unauthorized,

--- a/contracts/external-staking/src/msg.rs
+++ b/contracts/external-staking/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Coin, Uint128};
 
 use crate::state::Config;
 
@@ -52,4 +52,10 @@ pub struct UserInfo {
 #[cw_serde]
 pub struct UsersResponse {
     pub users: Vec<UserInfo>,
+}
+
+/// Response for penging rewards query
+#[cw_serde]
+pub struct PendingRewards {
+    pub amount: Coin,
 }

--- a/contracts/external-staking/src/multitest.rs
+++ b/contracts/external-staking/src/multitest.rs
@@ -12,11 +12,11 @@ use crate::contract::cross_staking::test_utils::CrossStakingApi;
 use crate::contract::multitest_utils::{CodeId, ExternalStakingContractProxy};
 use crate::error::ContractError;
 use crate::msg::{ReceiveVirtualStake, StakeInfo};
-use crate::state::Stake;
 
 use anyhow::Result as AnyResult;
 
 const OSMO: &str = "osmo";
+const STAR: &str = "star";
 
 // Shortcut setuping all needed contracts
 //
@@ -50,6 +50,7 @@ fn setup<'app>(
     let contract = contract_code
         .instantiate(
             OSMO.to_owned(),
+            STAR.to_owned(),
             vault.contract_addr.to_string(),
             unbond_period,
         )
@@ -196,46 +197,22 @@ fn staking() {
     let stake = contract
         .stake(users[0].to_owned(), validators[0].to_owned())
         .unwrap();
-    assert_eq!(
-        stake,
-        Stake {
-            stake: 200u128.into(),
-            pending_unbonds: vec![]
-        }
-    );
+    assert_eq!(stake.stake.u128(), 200);
 
     let stake = contract
         .stake(users[0].to_owned(), validators[1].to_owned())
         .unwrap();
-    assert_eq!(
-        stake,
-        Stake {
-            stake: 100u128.into(),
-            pending_unbonds: vec![]
-        }
-    );
+    assert_eq!(stake.stake.u128(), 100);
 
     let stake = contract
         .stake(users[1].to_owned(), validators[0].to_owned())
         .unwrap();
-    assert_eq!(
-        stake,
-        Stake {
-            stake: 100u128.into(),
-            pending_unbonds: vec![]
-        }
-    );
+    assert_eq!(stake.stake.u128(), 100);
 
     let stake = contract
         .stake(users[1].to_owned(), validators[1].to_owned())
         .unwrap();
-    assert_eq!(
-        stake,
-        Stake {
-            stake: 200u128.into(),
-            pending_unbonds: vec![]
-        }
-    );
+    assert_eq!(stake.stake.u128(), 200);
 
     // Querying fo all the stakes
     let stakes = contract.stakes(users[0].to_owned(), None, None).unwrap();

--- a/contracts/external-staking/src/state.rs
+++ b/contracts/external-staking/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{BlockInfo, Timestamp, Uint128};
+use cosmwasm_std::{BlockInfo, Timestamp, Uint128, Uint256};
 use mesh_apis::vault_api::VaultApiHelper;
 
 /// Contract configuration
@@ -7,15 +7,17 @@ use mesh_apis::vault_api::VaultApiHelper;
 pub struct Config {
     /// Local native token this contracts operate on
     pub denom: String,
+    /// Rewards token for this contract (remote IBC token)
+    pub rewards_denom: String,
     /// Vault contract address
     pub vault: VaultApiHelper,
     /// Ubbounding period for claims in seconds
     pub unbonding_period: u64,
 }
 
-/// All single stake related information - entry per `(user, validator)` pair
+/// All single stake related information - entry per `(user, validator)` pair, including
+/// distribution alignment
 #[cw_serde]
-#[derive(Default)]
 pub struct Stake {
     /// How much tokens user staken and not in unbonding period
     /// via this contract
@@ -26,6 +28,27 @@ pub struct Stake {
     /// `unbonding_period` after current time - this way this is guaranteed to be
     /// always sorted (as time is guaranteed to be monotonic).
     pub pending_unbonds: Vec<PendingUnbond>,
+    /// Points alignment is how much points should be added/substracted from points caltulated per
+    /// user due to stake changes. It has to be signed type, but no signed integrals are right now
+    /// in CosmWasm - using `Uint256` here as a "fake" type, so for calculations it is shifted - the
+    /// real value storedis `points_alignment - Uint256::MAX / 2` - this is not ideal, but it makes
+    /// calculations always fit in U256.
+    pub points_alignment: Uint256,
+    /// Tokens already withdrawn by this user
+    pub withdrawn_funds: Uint128,
+}
+
+impl Default for Stake {
+    fn default() -> Self {
+        Self {
+            stake: Default::default(),
+            pending_unbonds: Default::default(),
+            // We want this value to be shifted by `U256::MAX` for keeping calculations in
+            // reasonable range
+            points_alignment: Uint256::MAX / Uint256::from_u128(2),
+            withdrawn_funds: Default::default(),
+        }
+    }
 }
 
 /// Description of tokens in unbonding period
@@ -62,4 +85,16 @@ impl Stake {
             .map(|pending| pending.amount)
             .sum()
     }
+}
+
+/// Per validator distribution information
+#[cw_serde]
+#[derive(Default)]
+pub struct Distribution {
+    /// Total tokens staken on this validator by all users
+    pub total_stake: Uint128,
+    /// Points user is eligible to by single token staken
+    pub points_per_stake: Uint256,
+    /// Points which were not distributed previously
+    pub points_leftover: Uint256,
 }


### PR DESCRIPTION
Follow up of #42 

Addresses #13 

Implements only the fourth task mentioned in https://github.com/osmosis-labs/mesh-security/issues/13#issuecomment-1569538835.

I miss `Int256` and `Int128` really badly - we need to finish math. Not proud of a workaround, but at least I didn't copy-paste the whole type from some other contract. And it should work. I am aware that due to `u2` I could just `wrapping_add` and `wrapping_sub`, but then we lose debug control of out of bound.

Next upcoming in the next PR.