### PR TITLE
Add lock sync primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "schemars",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mesh-sync"
+version = "0.2.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "thiserror",
+]
+
+[[package]]
 name = "mesh-vault"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository    = "https://github.com/osmosis-labs/mesh-security"
 mesh-apis        = { path = "./packages/apis" }
 mesh-bindings        = { path = "./packages/bindings" }
 mesh-mocks        = { path = "./packages/mocks" }
+mesh-sync        = { path = "./packages/sync" }
 
 mesh-vault    = { path = "./contracts/provider/vault" }
 mesh-external-staking    = { path = "./contracts/provider/external-staking" }

--- a/packages/sync/Cargo.toml
+++ b/packages/sync/Cargo.toml
@@ -7,6 +7,8 @@ license       = { workspace = true }
 [dependencies]
 cosmwasm-std     = { workspace = true }
 cosmwasm-schema  = { workspace = true }
+serde        = { workspace = true }
+schemars        = { workspace = true }
 thiserror        = { workspace = true }
 
 [dev-dependencies]

--- a/packages/sync/Cargo.toml
+++ b/packages/sync/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mesh-sync"
+version = { workspace = true }
+edition = { workspace = true }
+license       = { workspace = true }
+
+[dependencies]
+cosmwasm-std     = { workspace = true }
+cosmwasm-schema  = { workspace = true }
+thiserror        = { workspace = true }
+
+[dev-dependencies]
+cw-storage-plus     = { workspace = true }
+
+

--- a/packages/sync/src/lib.rs
+++ b/packages/sync/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/packages/sync/src/lib.rs
+++ b/packages/sync/src/lib.rs
@@ -1,14 +1,3 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+mod locks;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use locks::{LockError, LockState, Lockable};

--- a/packages/sync/src/locks.rs
+++ b/packages/sync/src/locks.rs
@@ -1,0 +1,109 @@
+use cosmwasm_schema::cw_serde;
+use thiserror::Error;
+
+#[cw_serde]
+pub struct Lockable<T> {
+    inner: T,
+    lock: LockState,
+}
+
+#[cw_serde]
+pub enum LockState {
+    #[serde(rename = "no")]
+    Unlocked,
+    #[serde(rename = "w")]
+    WriteLocked,
+    #[serde(rename = "r")]
+    ReadLocked(u32),
+}
+
+#[derive(Debug, Error)]
+pub enum LockError {
+    #[error("Value is already write locked")]
+    WriteLocked,
+    #[error("Value is already read locked")]
+    ReadLocked,
+    #[error("Attempt to release a lock which was not held")]
+    NoLockHeld,
+}
+
+impl Default for LockState {
+    fn default() -> Self {
+        LockState::Unlocked
+    }
+}
+
+impl<T> Lockable<T> {
+    pub fn new(inner: T) -> Self {
+        Lockable {
+            inner,
+            lock: LockState::Unlocked,
+        }
+    }
+
+    pub fn read(&self) -> Result<&T, LockError> {
+        match self.lock {
+            LockState::WriteLocked => Err(LockError::WriteLocked),
+            _ => Ok(&self.inner),
+        }
+    }
+
+    pub fn write(&mut self) -> Result<&mut T, LockError> {
+        match self.lock {
+            LockState::WriteLocked => Err(LockError::WriteLocked),
+            LockState::ReadLocked(_) => Err(LockError::ReadLocked),
+            LockState::Unlocked => Ok(&mut self.inner),
+        }
+    }
+
+    pub fn lock_write(&mut self) -> Result<(), LockError> {
+        match self.lock {
+            LockState::Unlocked => {
+                self.lock = LockState::WriteLocked;
+                Ok(())
+            }
+            LockState::WriteLocked => Err(LockError::WriteLocked),
+            LockState::ReadLocked(_) => Err(LockError::ReadLocked),
+        }
+    }
+
+    pub fn lock_read(&mut self) -> Result<(), LockError> {
+        match self.lock {
+            LockState::Unlocked => {
+                self.lock = LockState::ReadLocked(1);
+                Ok(())
+            }
+            LockState::ReadLocked(x) => {
+                self.lock = LockState::ReadLocked(x + 1);
+                Ok(())
+            }
+            LockState::WriteLocked => Err(LockError::WriteLocked),
+        }
+    }
+
+    pub fn unlock_read(&mut self) -> Result<(), LockError> {
+        match self.lock {
+            LockState::Unlocked => Err(LockError::NoLockHeld),
+            LockState::ReadLocked(1) => {
+                self.lock = LockState::Unlocked;
+                Ok(())
+            }
+            LockState::ReadLocked(x) => {
+                self.lock = LockState::ReadLocked(x - 1);
+                Ok(())
+            }
+            LockState::WriteLocked => Err(LockError::WriteLocked),
+        }
+    }
+
+    pub fn unlock_write(&mut self) -> Result<(), LockError> {
+        match self.lock {
+            LockState::Unlocked => Err(LockError::NoLockHeld),
+            LockState::ReadLocked(_) => Err(LockError::ReadLocked),
+            LockState::WriteLocked => {
+                self.lock = LockState::Unlocked;
+                Ok(())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Based on the theoretical work in #49 

Define a `Lockable<T>` type that can be stored in an `Item` or `Map` and manages pending read or write locks in storage,
so as to hold them over multiple blocks until an IBC ack comes in.

The "normal" use now needs to be via `val.read()?` or `val.write()?` to get `&T` or `&mut T`, so a slight change to calling code, but not too bad. And there are new methods to lock or unlock it which can control whether the previous are allowed.
Also, usage in higher-level constructs (like `Map::range`) should enforce this and error if a single element has a write-lock.