### PR TITLE
Add ValueRange type

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           target: wasm32-unknown-unknown
           override: true
 
@@ -28,7 +28,7 @@ jobs:
       - name: Run build
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           command: build
           args: --workspace
         env:
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           command: test
           args: --workspace
         env:
@@ -46,7 +46,7 @@ jobs:
       - name: Compile WASM contract
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           command: wasm
         env:
           RUSTFLAGS: "-C link-arg=-s"
@@ -62,7 +62,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           override: true
           components: rustfmt, clippy
 
@@ -74,13 +74,13 @@ jobs:
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           command: fmt
           args: --all -- --check
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           command: clippy
           args: --all-targets -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           target: wasm32-unknown-unknown
           override: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ schema/
 schemas/
 
 .DS_Store
+.vscode
+.idea
 
 node_modules

--- a/packages/sync/src/lib.rs
+++ b/packages/sync/src/lib.rs
@@ -2,4 +2,4 @@ mod locks;
 mod range;
 
 pub use locks::{LockError, LockState, Lockable};
-pub use range::ValueRange;
+pub use range::{max_val, min_val, spread, RangeError, ValueRange};

--- a/packages/sync/src/lib.rs
+++ b/packages/sync/src/lib.rs
@@ -2,4 +2,4 @@ mod locks;
 mod range;
 
 pub use locks::{LockError, LockState, Lockable};
-pub use range::{max_val, min_val, spread, RangeError, ValueRange};
+pub use range::{max_range, min_range, spread, RangeError, ValueRange};

--- a/packages/sync/src/lib.rs
+++ b/packages/sync/src/lib.rs
@@ -1,3 +1,5 @@
 mod locks;
+mod range;
 
 pub use locks::{LockError, LockState, Lockable};
+pub use range::ValueRange;

--- a/packages/sync/src/range.rs
+++ b/packages/sync/src/range.rs
@@ -1,0 +1,131 @@
+use std::ops::{Add, Sub};
+use thiserror::Error;
+
+use cosmwasm_schema::cw_serde;
+
+/// This is designed to work with two numeric primitives that can be added, subtracted, and compared.
+#[cw_serde]
+pub struct ValueRange<T>(T, T);
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RangeError {
+    #[error("Underflow minimum value")]
+    Underflow,
+    #[error("Overflow maximum value")]
+    Overflow,
+}
+
+impl<T> ValueRange<T>
+where
+    T: Copy,
+{
+    pub fn new(value: T) -> Self {
+        Self(value, value)
+    }
+
+    pub fn min(&self) -> T {
+        self.0
+    }
+
+    pub fn max(&self) -> T {
+        self.1
+    }
+}
+
+impl<T> ValueRange<T>
+where
+    T: Add<Output = T> + Sub<Output = T> + PartialOrd + Ord + Copy,
+{
+    /// This is to be called at the beginning of a transaction, to reserve the ability to commit (or rollback) an addition
+    pub fn prepare_add(&mut self, value: T) -> Result<(), RangeError> {
+        // FIXME: assert some max?
+        self.1 = self.1 + value;
+        Ok(())
+    }
+
+    /// The caller should limit these to only previous `prepare_add` calls.
+    /// We will panic on mistake as this should never happen
+    pub fn rollback_add(&mut self, value: T) {
+        self.1 = self.1 - value;
+        self.assert_valid_range();
+    }
+
+    /// The caller should limit these to only previous `prepare_add` calls.
+    /// We will panic on mistake as this should never happen
+    pub fn commit_add(&mut self, value: T) {
+        self.0 = self.0 + value;
+        self.assert_valid_range();
+    }
+
+    /// This is to be called at the beginning of a transaction, to reserve the ability to commit (or rollback) a subtraction
+    pub fn prepare_sub(&mut self, value: T) -> Result<(), RangeError> {
+        if value < self.0 {
+            return Err(RangeError::Underflow);
+        }
+        self.0 = self.0 - value;
+        Ok(())
+    }
+
+    /// The caller should limit these to only previous `prepare_sub` calls.
+    /// We will panic on mistake as this should never happen
+    pub fn rollback_sub(&mut self, value: T) {
+        self.0 = self.0 + value;
+        self.assert_valid_range();
+    }
+
+    /// The caller should limit these to only previous `prepare_sub` calls.
+    /// We will panic on mistake as this should never happen
+    pub fn commit_sub(&mut self, value: T) {
+        self.1 = self.1 - value;
+        self.assert_valid_range();
+    }
+
+    #[inline]
+    fn assert_valid_range(&self) {
+        assert!(self.0 <= self.1);
+    }
+}
+
+impl<T: PartialOrd> PartialEq<T> for ValueRange<T> {
+    fn eq(&self, other: &T) -> bool {
+        self.0 == self.1 && self.0 == *other
+    }
+}
+
+impl<T: PartialOrd> PartialOrd<T> for ValueRange<T> {
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        if other < &self.0 {
+            Some(std::cmp::Ordering::Greater)
+        } else if other > &self.1 {
+            Some(std::cmp::Ordering::Less)
+        } else if self.eq(other) {
+            Some(std::cmp::Ordering::Equal)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comparisons() {
+        // check for one point - it behaves like an integer
+        let mut range = ValueRange::new(50);
+        assert!(range == 50);
+        assert!(range > 49);
+        assert!(range < 51);
+
+        // make a range (50, 80), it should compare normally to those outside the range
+        range.prepare_add(30).unwrap();
+        assert!(range > 49);
+        assert!(range < 81);
+
+        // all comparisons inside the range lead to false
+        assert!(!(range < 60));
+        assert!(!(range > 60));
+        assert!(range != 60);
+    }
+}


### PR DESCRIPTION
Requires #52 (merge that first)

This is inspired by the work in #49 about defining possible ranges of values as a lightweight partial lock for  in-flight IBC transactions

Basic functionality is there and tested. It would be good to have some more realistic tests cases to ensure this API would be useful in real conditions