### PR TITLE
External staking txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,9 +1005,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sylvia"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653fcc60f698f37931ea686ffa3f6669b18fabead296ca69e94226cf3e1e61ce"
+checksum = "66fc0aae39bc8a76742c1455e3bda09976224e31d236de0e468c91fbc2414c79"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "sylvia-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b670d5537a6ea500e240213e100d8dddacddfc00caabcdf798347909c42a73"
+checksum = "5c50a057bb2787c04dd93a203809e79d424d5de21b5024e23bc8d1cd5e6f34d4"
 dependencies = [
  "convert_case",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ mesh-converter    = { path = "./contracts/consumer/converter" }
 mesh-simple-price-feed    = { path = "./contracts/consumer/simple-price-feed" }
 mesh-virtual-staking    = { path = "./contracts/consumer/virtual-staking" }
 
-sylvia           = "0.4.2"
+sylvia           = "0.5.0"
 cosmwasm-schema  = "1.2"
 cosmwasm-std     = { version = "1.2", features = ["ibc3", "cosmwasm_1_2"] }
 cosmwasm-storage = "1.2"

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -10,6 +10,9 @@ use crate::contract::{NativeStakingContract, MAX_SLASH_PERCENTAGE, REPLY_ID_INST
 use crate::error::ContractError;
 use crate::msg::StakeMsg;
 
+// FIXME: Move to sylvia contract macro
+use crate::contract::BoundQuerier;
+
 #[contract]
 #[messages(local_staking_api as LocalStakingApi)]
 impl LocalStakingApi for NativeStakingContract<'_> {

--- a/contracts/provider/native-staking/src/native_staking_callback.rs
+++ b/contracts/provider/native-staking/src/native_staking_callback.rs
@@ -10,6 +10,9 @@ use mesh_native_staking_proxy::native_staking_callback::{self, NativeStakingCall
 use crate::contract::NativeStakingContract;
 use crate::error::ContractError;
 
+// FIXME: Move to sylvia contract macro
+use crate::contract::BoundQuerier;
+
 #[contract]
 #[messages(native_staking_callback as NativeStakingCallback)]
 impl NativeStakingCallback for NativeStakingContract<'_> {

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -548,6 +548,7 @@ impl VaultContract<'_> {
                 amount: Uint128::zero(),
                 slashable: tx.slashable,
             });
+        // Process tx
         lien.amount += tx.amount;
 
         let mut user = self
@@ -556,9 +557,6 @@ impl VaultContract<'_> {
             .unwrap_or_default();
         user.max_lien = user.max_lien.max(lien.amount);
         user.total_slashable += tx.amount * lien.slashable;
-
-        // FIXME: Remove, as it's a redundant check
-        ensure!(user.verify_collateral(), ContractError::InsufficentBalance);
 
         self.liens
             .save(ctx.deps.storage, (&ctx.info.sender, &tx.lienholder), &lien)?;

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -506,6 +506,7 @@ impl VaultContract<'_> {
             .users
             .may_load(ctx.deps.storage, &ctx.info.sender)?
             .unwrap_or_default();
+        // TODO: Prove / check correctness
         user.max_lien = user.max_lien.max(pending_amount);
         user.total_slashable += pending_amount * lien.slashable;
 

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -493,7 +493,7 @@ impl VaultContract<'_> {
                     })
                 })?;
 
-        // Load lien and update (but do not save) user info and lien holder
+        // Load lien (to get slashable), and update (but do not save) user info for collateral check
         let lien = self
             .liens
             .may_load(ctx.deps.storage, (&ctx.info.sender, lienholder))?
@@ -506,7 +506,7 @@ impl VaultContract<'_> {
             .users
             .may_load(ctx.deps.storage, &ctx.info.sender)?
             .unwrap_or_default();
-        user.max_lien = user.max_lien.max(lien.amount);
+        user.max_lien = user.max_lien.max(pending_amount);
         user.total_slashable += pending_amount * lien.slashable;
 
         ensure!(user.verify_collateral(), ContractError::InsufficentBalance);

--- a/contracts/provider/vault/src/error.rs
+++ b/contracts/provider/vault/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{StdError, Uint128};
+use cosmwasm_std::{Addr, StdError, Uint128};
 use cw_utils::{ParseReplyError, PaymentError};
 use thiserror::Error;
 
@@ -33,4 +33,7 @@ pub enum ContractError {
 
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
+
+    #[error("The tx {0} exists but comes from the wrong address: {1}")]
+    WrongContractTx(u64, Addr),
 }

--- a/contracts/provider/vault/src/lib.rs
+++ b/contracts/provider/vault/src/lib.rs
@@ -4,3 +4,4 @@ pub mod msg;
 #[cfg(test)]
 mod multitest;
 mod state;
+pub mod txs;

--- a/contracts/provider/vault/src/txs.rs
+++ b/contracts/provider/vault/src/txs.rs
@@ -1,0 +1,52 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Decimal, Uint128};
+use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
+
+#[cw_serde]
+pub enum TxType {
+    Stake,
+    Unstake,
+    // TODO
+    // Slash,
+}
+
+#[cw_serde]
+pub struct Tx {
+    /// Transaction type
+    pub ty: TxType,
+    /// Associated amount
+    pub amount: Uint128,
+    /// Slashable portion of lien
+    pub slashable: Decimal,
+    /// Associated user
+    pub user: Addr,
+    /// Remote staking contract
+    pub lienholder: Addr,
+}
+
+pub struct TxIndexes<'a> {
+    // Last type param defines the pk deserialization type
+    pub users: MultiIndex<'a, Addr, Tx, Addr>,
+}
+
+impl<'a> IndexList<Tx> for TxIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Tx>> + '_> {
+        let v: Vec<&dyn Index<Tx>> = vec![&self.users];
+        Box::new(v.into_iter())
+    }
+}
+
+pub struct Txs<'a> {
+    pub txs: IndexedMap<'a, u64, Tx, TxIndexes<'a>>,
+}
+
+impl<'a> Txs<'a> {
+    pub fn new(storage_key: &'a str, user_subkey: &'a str) -> Self {
+        let indexes = TxIndexes {
+            users: MultiIndex::new(|_, tx| tx.user.clone(), storage_key, user_subkey),
+        };
+        let txs = IndexedMap::new(storage_key, indexes);
+
+        Self { txs }
+    }
+}


### PR DESCRIPTION
Proof of concept / exploration of transactional remote staking functionality.

Draws from some of the ideas discussed in #49, but does a bare-bones / straightforward impl for clarity. Value ranges are implemented through filtering over transaction types, and a map of pending txs is used for persistence / tracking.

If this is accepted, it can eventually mature and turn into a package or module for implementing the same in other contracts, and supporting other transaction types.

Also, a full impl of this would perhaps require something like two phase commits, as these transactions can involve multiple contracts, and things can fail in any of them.

TODO:

- Transactional remote unstake.
- Packaging.
- Tests.
- Remote slashing.
- ...