### PR TITLE
External stacking locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "mesh-apis",
  "mesh-native-staking",
  "mesh-native-staking-proxy",
+ "mesh-sync",
  "mesh-vault",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,9 +1017,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sylvia"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653fcc60f698f37931ea686ffa3f6669b18fabead296ca69e94226cf3e1e61ce"
+checksum = "66fc0aae39bc8a76742c1455e3bda09976224e31d236de0e468c91fbc2414c79"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "sylvia-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b670d5537a6ea500e240213e100d8dddacddfc00caabcdf798347909c42a73"
+checksum = "5c50a057bb2787c04dd93a203809e79d424d5de21b5024e23bc8d1cd5e6f34d4"
 dependencies = [
  "convert_case",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "cw2",
  "derivative",
  "mesh-apis",
+ "mesh-sync",
  "schemars",
  "serde",
  "sylvia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ mesh-converter    = { path = "./contracts/consumer/converter" }
 mesh-simple-price-feed    = { path = "./contracts/consumer/simple-price-feed" }
 mesh-virtual-staking    = { path = "./contracts/consumer/virtual-staking" }
 
-sylvia           = "0.4.2"
+sylvia           = "0.5.0"
 cosmwasm-schema  = "1.2"
 cosmwasm-std     = { version = "1.2", features = ["ibc3", "cosmwasm_1_2"] }
 cosmwasm-storage = "1.2"

--- a/contracts/provider/external-staking/Cargo.toml
+++ b/contracts/provider/external-staking/Cargo.toml
@@ -39,6 +39,7 @@ anyhow        = { workspace = true }
 mesh-vault = { workspace = true, features = ["mt"] }
 mesh-native-staking-proxy = { workspace = true, features = ["mt"] }
 mesh-native-staking = { workspace = true, features = ["mt"] }
+mesh-sync = { workspace = true }
 
 [[bin]]
 name = "schema"

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -391,6 +391,7 @@ pub mod cross_staking {
             ctx: ExecCtx,
             owner: String,
             amount: Coin,
+            _tx_id: u64,
             msg: Binary,
         ) -> Result<Response, Self::Error> {
             let config = self.config.load(ctx.deps.storage)?;

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -391,7 +391,7 @@ pub mod cross_staking {
             ctx: ExecCtx,
             owner: String,
             amount: Coin,
-            _tx_id: u64,
+            tx_id: u64,
             msg: Binary,
         ) -> Result<Response, Self::Error> {
             let config = self.config.load(ctx.deps.storage)?;
@@ -436,7 +436,7 @@ pub mod cross_staking {
                 .add_attribute("action", "receive_virtual_stake")
                 .add_attribute("owner", owner)
                 .add_attribute("amount", amount.amount.to_string())
-                .add_attribute("tx_id", msg.tx.to_string());
+                .add_attribute("tx_id", tx_id.to_string());
 
             Ok(resp)
         }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -435,7 +435,8 @@ pub mod cross_staking {
             let resp = Response::new()
                 .add_attribute("action", "receive_virtual_stake")
                 .add_attribute("owner", owner)
-                .add_attribute("amount", amount.amount.to_string());
+                .add_attribute("amount", amount.amount.to_string())
+                .add_attribute("tx_id", msg.tx.to_string());
 
             Ok(resp)
         }

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -39,8 +39,6 @@ pub struct StakesResponse {
 /// Message to be send as `msg` field on `receive_virtual_staking`
 #[cw_serde]
 pub struct ReceiveVirtualStake {
-    /// Associated transaction id
-    pub tx: u64,
     pub validator: String,
 }
 

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -39,6 +39,8 @@ pub struct StakesResponse {
 /// Message to be send as `msg` field on `receive_virtual_staking`
 #[cw_serde]
 pub struct ReceiveVirtualStake {
+    /// Associated transaction id
+    pub tx: u64,
     pub validator: String,
 }
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -284,7 +284,7 @@ fn staking() {
 #[track_caller]
 fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
     let txs = vault.all_pending_txs(None, None).unwrap().txs;
-    txs.last().map(|tx| tx.id)
+    txs.first().map(|tx| tx.id)
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -128,9 +128,7 @@ fn staking() {
         .call(users[0])
         .unwrap();
 
-    // Hardcoded commit tx call
-    // TODO: get last tx helper
-    let mut last_tx = 1;
+    let last_tx = get_last_pending_tx_id(&vault).unwrap();
     vault
         .vault_api_proxy()
         .commit_tx(last_tx)
@@ -149,10 +147,9 @@ fn staking() {
         .call(users[0])
         .unwrap();
 
-    last_tx += 1;
     vault
         .vault_api_proxy()
-        .commit_tx(last_tx)
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
         .call(contract.contract_addr.as_str())
         .unwrap();
 
@@ -168,10 +165,9 @@ fn staking() {
         .call(users[0])
         .unwrap();
 
-    last_tx += 1;
     vault
         .vault_api_proxy()
-        .commit_tx(last_tx)
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
         .call(contract.contract_addr.as_str())
         .unwrap();
 
@@ -187,10 +183,9 @@ fn staking() {
         .call(users[1])
         .unwrap();
 
-    last_tx += 1;
     vault
         .vault_api_proxy()
-        .commit_tx(last_tx)
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
         .call(contract.contract_addr.as_str())
         .unwrap();
 
@@ -205,11 +200,9 @@ fn staking() {
         )
         .call(users[1])
         .unwrap();
-
-    last_tx += 1;
     vault
         .vault_api_proxy()
-        .commit_tx(last_tx)
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
         .call(contract.contract_addr.as_str())
         .unwrap();
 
@@ -286,6 +279,12 @@ fn staking() {
             },
         ]
     );
+}
+
+#[track_caller]
+fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
+    let txs = vault.all_pending_txs(None, None).unwrap().txs;
+    txs.last().map(|tx| tx.id)
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -638,6 +638,12 @@ fn distribution() {
         )
         .call(users[0])
         .unwrap();
+    // Hardcoded commit_tx call (lack of IBC support yet)
+    vault
+        .vault_api_proxy()
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
+        .call(contract.contract_addr.as_str())
+        .unwrap();
 
     vault
         .stake_remote(
@@ -650,6 +656,11 @@ fn distribution() {
         )
         .call(users[0])
         .unwrap();
+    vault
+        .vault_api_proxy()
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
+        .call(contract.contract_addr.as_str())
+        .unwrap();
 
     vault
         .stake_remote(
@@ -661,6 +672,11 @@ fn distribution() {
             .unwrap(),
         )
         .call(users[1])
+        .unwrap();
+    vault
+        .vault_api_proxy()
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
+        .call(contract.contract_addr.as_str())
         .unwrap();
 
     // Start with equal distribution:

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -129,6 +129,7 @@ fn staking() {
         .unwrap();
 
     let last_tx = get_last_pending_tx_id(&vault).unwrap();
+    // Hardcoded commit_tx call (lack of IBC support yet)
     vault
         .vault_api_proxy()
         .commit_tx(last_tx)
@@ -337,6 +338,13 @@ fn unstaking() {
         )
         .call(users[0])
         .unwrap();
+    let last_tx = get_last_pending_tx_id(&vault).unwrap();
+    // Hardcoded commit_tx call (lack of IBC support yet)
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(contract.contract_addr.as_str())
+        .unwrap();
 
     vault
         .stake_remote(
@@ -349,6 +357,11 @@ fn unstaking() {
         )
         .call(users[0])
         .unwrap();
+    vault
+        .vault_api_proxy()
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
+        .call(contract.contract_addr.as_str())
+        .unwrap();
 
     vault
         .stake_remote(
@@ -360,6 +373,11 @@ fn unstaking() {
             .unwrap(),
         )
         .call(users[1])
+        .unwrap();
+    vault
+        .vault_api_proxy()
+        .commit_tx(get_last_pending_tx_id(&vault).unwrap())
+        .call(contract.contract_addr.as_str())
         .unwrap();
 
     // Properly unstake some tokens

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1,3 +1,5 @@
+use anyhow::Result as AnyResult;
+
 use cosmwasm_std::{coin, coins, to_binary, Addr, Decimal};
 use mesh_native_staking::contract::multitest_utils::CodeId as NativeStakingCodeId;
 use mesh_native_staking::contract::InstantiateMsg as NativeStakingInstantiateMsg;
@@ -6,6 +8,8 @@ use mesh_vault::contract::multitest_utils::{CodeId as VaultCodeId, VaultContract
 use mesh_vault::contract::test_utils::VaultApi;
 use mesh_vault::msg::StakingInitInfo;
 
+use mesh_sync::Tx;
+
 use cw_multi_test::App as MtApp;
 use sylvia::multitest::App;
 
@@ -13,8 +17,6 @@ use crate::contract::cross_staking::test_utils::CrossStakingApi;
 use crate::contract::multitest_utils::{CodeId, ExternalStakingContractProxy};
 use crate::error::ContractError;
 use crate::msg::{ReceiveVirtualStake, StakeInfo};
-
-use anyhow::Result as AnyResult;
 
 const OSMO: &str = "osmo";
 const STAR: &str = "star";
@@ -285,7 +287,9 @@ fn staking() {
 #[track_caller]
 fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
     let txs = vault.all_pending_txs(None, None).unwrap().txs;
-    txs.first().map(|tx| tx.id)
+    txs.first().map(|tx| match tx {
+        Tx::InFlightStaking { id, .. } => *id,
+    })
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -3,6 +3,7 @@ use mesh_native_staking::contract::multitest_utils::CodeId as NativeStakingCodeI
 use mesh_native_staking::contract::InstantiateMsg as NativeStakingInstantiateMsg;
 use mesh_native_staking_proxy::contract::multitest_utils::CodeId as NativeStakingProxyCodeId;
 use mesh_vault::contract::multitest_utils::{CodeId as VaultCodeId, VaultContractProxy};
+use mesh_vault::contract::test_utils::VaultApi;
 use mesh_vault::msg::StakingInitInfo;
 
 use cw_multi_test::App as MtApp;
@@ -127,7 +128,14 @@ fn staking() {
         .call(users[0])
         .unwrap();
 
-    // Need to process / commit IBC tx here
+    // Hardcoded commit tx call
+    // TODO: get last tx helper
+    let mut last_tx = 1;
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(contract.contract_addr.as_str())
+        .unwrap();
 
     vault
         .stake_remote(
@@ -141,6 +149,13 @@ fn staking() {
         .call(users[0])
         .unwrap();
 
+    last_tx += 1;
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(contract.contract_addr.as_str())
+        .unwrap();
+
     vault
         .stake_remote(
             contract.contract_addr.to_string(),
@@ -151,6 +166,13 @@ fn staking() {
             .unwrap(),
         )
         .call(users[0])
+        .unwrap();
+
+    last_tx += 1;
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(contract.contract_addr.as_str())
         .unwrap();
 
     vault
@@ -165,6 +187,13 @@ fn staking() {
         .call(users[1])
         .unwrap();
 
+    last_tx += 1;
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(contract.contract_addr.as_str())
+        .unwrap();
+
     vault
         .stake_remote(
             contract.contract_addr.to_string(),
@@ -175,6 +204,13 @@ fn staking() {
             .unwrap(),
         )
         .call(users[1])
+        .unwrap();
+
+    last_tx += 1;
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(contract.contract_addr.as_str())
         .unwrap();
 
     // All tokens should be only on the vault contract

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -120,6 +120,7 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 1,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -132,6 +133,7 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -144,6 +146,7 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 3,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -156,6 +159,7 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(200, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 4,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -168,6 +172,7 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 5,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -294,6 +299,7 @@ fn unstaking() {
             contract.contract_addr.to_string(),
             coin(200, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 1,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -306,6 +312,7 @@ fn unstaking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -318,6 +325,7 @@ fn unstaking() {
             contract.contract_addr.to_string(),
             coin(300, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 3,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -577,6 +585,7 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(200, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 1,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -589,6 +598,7 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -601,6 +611,7 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(300, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 3,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -818,6 +829,7 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(300, OSMO),
             to_binary(&ReceiveVirtualStake {
+                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -286,7 +286,7 @@ fn staking() {
 
 #[track_caller]
 fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
-    let txs = vault.all_pending_txs(None, None).unwrap().txs;
+    let txs = vault.all_pending_txs_desc(None, None).unwrap().txs;
     txs.first().map(|tx| match tx {
         Tx::InFlightStaking { id, .. } => *id,
     })

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -120,7 +120,6 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 1,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -128,12 +127,13 @@ fn staking() {
         .call(users[0])
         .unwrap();
 
+    // Need to process / commit IBC tx here
+
     vault
         .stake_remote(
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -146,7 +146,6 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 3,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -159,7 +158,6 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(200, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 4,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -172,7 +170,6 @@ fn staking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 5,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -299,7 +296,6 @@ fn unstaking() {
             contract.contract_addr.to_string(),
             coin(200, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 1,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -312,7 +308,6 @@ fn unstaking() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -325,7 +320,6 @@ fn unstaking() {
             contract.contract_addr.to_string(),
             coin(300, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 3,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -585,7 +579,6 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(200, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 1,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -598,7 +591,6 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(100, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -611,7 +603,6 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(300, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 3,
                 validator: validators[0].to_string(),
             })
             .unwrap(),
@@ -829,7 +820,6 @@ fn distribution() {
             contract.contract_addr.to_string(),
             coin(300, OSMO),
             to_binary(&ReceiveVirtualStake {
-                tx: 2,
                 validator: validators[1].to_string(),
             })
             .unwrap(),

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -10,6 +10,9 @@ use crate::contract::{NativeStakingContract, MAX_SLASH_PERCENTAGE, REPLY_ID_INST
 use crate::error::ContractError;
 use crate::msg::StakeMsg;
 
+// FIXME: Move to sylvia contract macro
+use crate::contract::BoundQuerier;
+
 #[contract]
 #[messages(local_staking_api as LocalStakingApi)]
 impl LocalStakingApi for NativeStakingContract<'_> {

--- a/contracts/provider/native-staking/src/native_staking_callback.rs
+++ b/contracts/provider/native-staking/src/native_staking_callback.rs
@@ -10,6 +10,9 @@ use mesh_native_staking_proxy::native_staking_callback::{self, NativeStakingCall
 use crate::contract::NativeStakingContract;
 use crate::error::ContractError;
 
+// FIXME: Move to sylvia contract macro
+use crate::contract::BoundQuerier;
+
 #[contract]
 #[messages(native_staking_callback as NativeStakingCallback)]
 impl NativeStakingCallback for NativeStakingContract<'_> {

--- a/contracts/provider/vault/Cargo.toml
+++ b/contracts/provider/vault/Cargo.toml
@@ -20,6 +20,7 @@ mt = ["library", "sylvia/mt"]
 
 [dependencies]
 mesh-apis        = { workspace = true }
+mesh-sync        = { workspace = true }
 
 sylvia = { workspace = true }
 cosmwasm-schema  = { workspace = true }

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -370,7 +370,7 @@ impl VaultContract<'_> {
                             // FIXME: This skips write-locked accounts
                             match account_lock.read() {
                                 Ok(account) => account.collateral.is_zero(),
-                                Err(_) => false,
+                                Err(_) => true,
                             }
                         })
                         .unwrap_or(false))

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -450,10 +450,12 @@ impl VaultContract<'_> {
         let mut lien_lock = self
             .liens
             .may_load(ctx.deps.storage, (&ctx.info.sender, lienholder))?
-            .unwrap_or(Lockable::new(Lien {
-                amount: Uint128::zero(),
-                slashable,
-            }));
+            .unwrap_or_else(|| {
+                Lockable::new(Lien {
+                    amount: Uint128::zero(),
+                    slashable,
+                })
+            });
         let lien = lien_lock.write()?;
         lien.amount += amount;
 

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -370,6 +370,7 @@ impl VaultContract<'_> {
                         account_lock
                             .read()
                             .map(|account| !with_collateral || !account.collateral.is_zero()) // Skip zero collateral
+                            // FIXME: Don't skip write-locked accounts (map to `MaybeAccount` wrapper)
                             .unwrap_or(false) // Skip write-locked accounts
                     })
                     .unwrap_or(false) // Skip other errors

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -406,7 +406,7 @@ impl VaultContract<'_> {
     /// Reports txs in descending order (newest first).
     /// `start_after` is the last tx id included in previous page
     #[msg(query)]
-    fn all_pending_txs(
+    fn all_pending_txs_desc(
         &self,
         ctx: QueryCtx,
         start_after: Option<u64>,

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -586,7 +586,7 @@ impl VaultContract<'_> {
         // Load user
         let mut user_lock = self.users.load(ctx.deps.storage, &tx.user)?;
         // Rollback user's max_lien (need to unlock it first)
-        lien_lock.unlock_write()?;
+        user_lock.unlock_write()?;
         let mut user = user_lock.write()?;
 
         // Max lien has to be recalculated from scratch; the just rolled back lien

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -683,11 +683,10 @@ impl VaultContract<'_> {
             .liens
             .may_load(ctx.deps.storage, (&owner, &ctx.info.sender))?
             .ok_or(ContractError::UnknownLienholder)?;
-        let lien = lien_lock.read()?;
+        let lien = lien_lock.write()?;
 
         ensure!(lien.amount >= amount, ContractError::InsufficientLien);
         let slashable = lien.slashable;
-        let lien = lien_lock.write()?;
         lien.amount -= amount;
 
         self.liens

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -192,7 +192,7 @@ impl VaultContract<'_> {
         let stake_msg = contract.receive_virtual_stake(
             ctx.info.sender.to_string(),
             amount.clone(),
-            // tx_id, TODO: Pass it along
+            tx_id,
             msg,
             vec![],
         )?;

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -582,8 +582,6 @@ impl VaultContract<'_> {
         lien_lock.unlock_write()?;
         let lien = lien_lock.write()?;
         lien.amount -= tx.amount;
-        // Unlock lien
-        lien_lock.unlock_write()?;
         // Save it unlocked
         self.liens.save(
             ctx.deps.storage,

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -391,6 +391,7 @@ impl VaultContract<'_> {
     }
 
     /// Queries for all pending txs.
+    /// Reports txs in descending order (newest first).
     /// `start_after` is the last tx id included in previous page
     #[msg(query)]
     fn all_pending_txs(
@@ -405,7 +406,7 @@ impl VaultContract<'_> {
         let txs = self
             .pending
             .txs
-            .range(ctx.deps.storage, bound, None, Order::Ascending)
+            .range(ctx.deps.storage, bound, None, Order::Descending)
             .map(|item| {
                 let (_id, tx) = item?;
                 Ok::<AllTxsResponseItem, ContractError>(tx)

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -515,11 +515,8 @@ impl VaultContract<'_> {
         // Unlock it
         lien_lock.unlock_write()?;
         // Save it
-        self.liens.save(
-            ctx.deps.storage,
-            (&ctx.info.sender, &tx.lienholder),
-            &lien_lock,
-        )?;
+        self.liens
+            .save(ctx.deps.storage, (&tx.user, &tx.lienholder), &lien_lock)?;
         // Load user
         let mut user_lock = self.users.load(ctx.deps.storage, &tx.user)?;
         // Unlock it
@@ -552,11 +549,8 @@ impl VaultContract<'_> {
         let lien = lien_lock.write()?;
         lien.amount -= tx.amount;
         // Save it unlocked
-        self.liens.save(
-            ctx.deps.storage,
-            (&ctx.info.sender, &tx.lienholder),
-            &lien_lock,
-        )?;
+        self.liens
+            .save(ctx.deps.storage, (&tx.user, &tx.lienholder), &lien_lock)?;
 
         // Load user
         let mut user_lock = self.users.load(ctx.deps.storage, &tx.user)?;

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -16,7 +16,10 @@ use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx, ReplyCtx};
 use sylvia::{contract, schemars};
 
 use crate::error::ContractError;
-use crate::msg::{AccountClaimsResponse, AccountResponse, AllAccountsResponse, AllAccountsResponseItem, AllTxsResponse, AllTxsResponseItem, ConfigResponse, LienInfo, StakingInitInfo};
+use crate::msg::{
+    AccountClaimsResponse, AccountResponse, AllAccountsResponse, AllAccountsResponseItem,
+    AllTxsResponse, AllTxsResponseItem, ConfigResponse, LienInfo, StakingInitInfo,
+};
 use crate::state::{Config, Lien, LocalStaking, UserInfo};
 use crate::txs::{Tx, TxType, Txs};
 

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -520,6 +520,12 @@ impl VaultContract<'_> {
             (&ctx.info.sender, &tx.lienholder),
             &lien_lock,
         )?;
+        // Load user
+        let mut user_lock = self.users.load(ctx.deps.storage, &tx.user)?;
+        // Unlock it
+        user_lock.unlock_write()?;
+        // Save it
+        self.users.save(ctx.deps.storage, &tx.user, &user_lock)?;
 
         // Remove tx
         self.pending.txs.remove(ctx.deps.storage, tx_id)?;

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -18,7 +18,7 @@ use sylvia::{contract, schemars};
 use crate::error::ContractError;
 use crate::msg::{
     AccountClaimsResponse, AccountResponse, AllAccountsResponse, AllAccountsResponseItem,
-    AllTxsResponse, AllTxsResponseItem, ConfigResponse, LienInfo, StakingInitInfo,
+    AllTxsResponse, AllTxsResponseItem, ConfigResponse, LienInfo, StakingInitInfo, TxResponse,
 };
 use crate::state::{Config, Lien, LocalStaking, UserInfo};
 use crate::txs::{Tx, TxType, Txs};
@@ -390,6 +390,13 @@ impl VaultContract<'_> {
 
         let resp = AllAccountsResponse { accounts };
 
+        Ok(resp)
+    }
+
+    /// Queries a pending tx.
+    #[msg(query)]
+    fn pending_tx(&self, ctx: QueryCtx, tx_id: u64) -> Result<TxResponse, ContractError> {
+        let resp = self.pending.txs.load(ctx.deps.storage, tx_id)?;
         Ok(resp)
     }
 

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -342,9 +342,9 @@ impl VaultContract<'_> {
     /// Queries for all users ever performing action in the system, paginating over
     /// them.
     ///
-    /// `start_after` is the last accoutn inlcuded in previous page
+    /// `start_after` is the last account included in previous page
     ///
-    /// `with_collateral` flag filters out users with no collateral, defualted to false
+    /// `with_collateral` flag filters out users with no collateral, defaulted to false
     #[msg(query)]
     fn all_accounts(
         &self,

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -406,7 +406,7 @@ impl VaultContract<'_> {
         let txs = self
             .pending
             .txs
-            .range(ctx.deps.storage, bound, None, Order::Descending)
+            .range(ctx.deps.storage, None, bound, Order::Descending)
             .map(|item| {
                 let (_id, tx) = item?;
                 Ok::<AllTxsResponseItem, ContractError>(tx)

--- a/contracts/provider/vault/src/error.rs
+++ b/contracts/provider/vault/src/error.rs
@@ -34,6 +34,9 @@ pub enum ContractError {
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
 
+    #[error("Transaction {0} is still pending")]
+    PendingTx(u64),
+
     #[error("The tx {0} exists but comes from the wrong address: {1}")]
     WrongContractTx(u64, Addr),
 }

--- a/contracts/provider/vault/src/error.rs
+++ b/contracts/provider/vault/src/error.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{Addr, StdError, Uint128};
 use cw_utils::{ParseReplyError, PaymentError};
+use mesh_sync::LockError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -12,6 +13,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     ParseReply(#[from] ParseReplyError),
+
+    #[error("{0}")]
+    Lock(#[from] LockError),
 
     #[error("Unauthorized")]
     Unauthorized {},
@@ -33,9 +37,6 @@ pub enum ContractError {
 
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
-
-    #[error("Transaction {0} is still pending")]
-    PendingTx(u64),
 
     #[error("The tx {0} exists but comes from the wrong address: {1}")]
     WrongContractTx(u64, Addr),

--- a/contracts/provider/vault/src/error.rs
+++ b/contracts/provider/vault/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Addr, StdError, Uint128};
 use cw_utils::{ParseReplyError, PaymentError};
-use mesh_sync::LockError;
+use mesh_sync::{LockError, Tx};
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -37,6 +37,9 @@ pub enum ContractError {
 
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
+
+    #[error("The tx {0} exists but is of the wrong type: {1}")]
+    WrongTypeTx(u64, Tx),
 
     #[error("The tx {0} exists but comes from the wrong address: {1}")]
     WrongContractTx(u64, Addr),

--- a/contracts/provider/vault/src/error.rs
+++ b/contracts/provider/vault/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{StdError, Uint128};
+use cosmwasm_std::{Addr, StdError, Uint128};
 use cw_utils::{ParseReplyError, PaymentError};
 use thiserror::Error;
 
@@ -33,4 +33,7 @@ pub enum ContractError {
 
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
+
+    #[error("The tx {0} exists but comes from the wrong address: {1}")]
+    WrongContractTx(u64, Addr),
 }

--- a/contracts/provider/vault/src/lib.rs
+++ b/contracts/provider/vault/src/lib.rs
@@ -4,3 +4,4 @@ pub mod msg;
 #[cfg(test)]
 mod multitest;
 mod state;
+pub mod txs;

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Binary, Uint128};
+use mesh_sync::Tx;
 
 /// This is the info used to construct the native staking contract
 #[cw_serde]
@@ -53,7 +54,7 @@ pub struct ConfigResponse {
     pub local_staking: String,
 }
 
-pub type TxResponse = crate::txs::Tx;
+pub type TxResponse = Tx;
 pub type AllTxsResponseItem = TxResponse;
 
 #[cw_serde]

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -52,3 +52,10 @@ pub struct ConfigResponse {
     pub denom: String,
     pub local_staking: String,
 }
+
+pub type AllTxsResponseItem = crate::txs::Tx;
+
+#[cw_serde]
+pub struct AllTxsResponse {
+    pub txs: Vec<AllTxsResponseItem>,
+}

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -53,7 +53,8 @@ pub struct ConfigResponse {
     pub local_staking: String,
 }
 
-pub type AllTxsResponseItem = crate::txs::Tx;
+pub type TxResponse = crate::txs::Tx;
+pub type AllTxsResponseItem = TxResponse;
 
 #[cw_serde]
 pub struct AllTxsResponse {

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -906,19 +906,16 @@ fn stake_cross_txs() {
         coin(800, OSMO)
     );
     // Can query all accounts, but locked ones are not returned
-    // FIXME: range() fails with ParseError!
-    // let accounts = vault.all_accounts(false, None, None).unwrap();
-    // assert_eq!(
-    //     accounts.accounts,
-    //     [AllAccountsResponseItem {
-    //         account: user2.to_string(),
-    //         denom: OSMO.to_owned(),
-    //         bonded: Uint128::new(500),
-    //         free: Uint128::new(400),
-    //     }]
-    // );
-    let err = vault.all_accounts(false, None, None).unwrap_err();
-    println!("err: {:#?}", err);
+    let accounts = vault.all_accounts(false, None, None).unwrap();
+    assert_eq!(
+        accounts.accounts,
+        [AllAccountsResponseItem {
+            account: user2.to_string(),
+            denom: OSMO.to_owned(),
+            bonded: Uint128::new(500),
+            free: Uint128::new(400),
+        }]
+    );
 
     // Can query the other account
     let acc = vault.account(user2.to_owned()).unwrap();

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -885,6 +885,14 @@ fn stake_cross_txs() {
     // Cannot query claims while pending
     assert!(matches!(vault.account_claims(user.to_owned(), None, None).unwrap_err(),
                ContractError::Std(GenericErr {..}))); // write locked
+    // Can query vault's balance while pending
+    assert_eq!(
+        app.app()
+            .wrap()
+            .query_balance(&vault.contract_addr, OSMO)
+            .unwrap(),
+        coin(800, OSMO)
+    );
 
     // Can query the other account
     let acc = vault.account(user2.to_owned()).unwrap();

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -511,7 +511,7 @@ fn stake_cross() {
         coin(0, OSMO)
     );
 
-    // Staking localy
+    // Staking remotely
 
     vault
         .stake_remote(

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -7,7 +7,9 @@ use crate::error::ContractError;
 use crate::msg::{AllAccountsResponseItem, LienInfo, StakingInitInfo};
 use crate::{contract, msg::AccountResponse};
 use cosmwasm_std::{coin, coins, to_binary, Addr, Binary, Decimal, Empty, Uint128};
+use cosmwasm_std::StdError::GenericErr;
 use cw_multi_test::App as MtApp;
+use mesh_sync::LockError;
 use sylvia::multitest::App;
 
 const OSMO: &str = "OSMO";
@@ -730,6 +732,213 @@ fn stake_cross() {
         )
         .call(owner)
         .unwrap_err();
+}
+
+#[test]
+fn stake_cross_txs() {
+    let owner = "owner";
+    let user = "user1";
+    let user2 = "user2";
+
+    let app = MtApp::new(|router, _api, storage| {
+        router
+            .bank
+            .init_balance(storage, &Addr::unchecked(user), coins(300, OSMO))
+            .unwrap();
+        router
+            .bank
+            .init_balance(storage, &Addr::unchecked(user2), coins(500, OSMO))
+            .unwrap();
+    });
+    let app = App::new(app);
+
+    // Contracts setup
+
+    let local_staking_code = local_staking::multitest_utils::CodeId::store_code(&app);
+    let cross_staking_code = cross_staking::multitest_utils::CodeId::store_code(&app);
+    let vault_code = contract::multitest_utils::CodeId::store_code(&app);
+
+    let cross_staking = cross_staking_code
+        .instantiate(Decimal::percent(10))
+        .call(owner)
+        .unwrap();
+
+    let staking_init_info = StakingInitInfo {
+        admin: None,
+        code_id: local_staking_code.code_id(),
+        msg: to_binary(&Empty {}).unwrap(),
+        label: None,
+    };
+
+    let vault = vault_code
+        .instantiate(OSMO.to_owned(), staking_init_info)
+        .with_label("Vault")
+        .call(owner)
+        .unwrap();
+
+    // Bond some tokens
+
+    vault
+        .bond()
+        .with_funds(&coins(300, OSMO))
+        .call(user)
+        .unwrap();
+
+    assert_eq!(
+        vault.account(user.to_owned()).unwrap(),
+        AccountResponse {
+            denom: OSMO.to_owned(),
+            bonded: Uint128::new(300),
+            free: Uint128::new(300),
+        }
+    );
+    let claims = vault.account_claims(user.to_owned(), None, None).unwrap();
+    assert_eq!(claims.claims, []);
+
+    vault
+        .bond()
+        .with_funds(&coins(500, OSMO))
+        .call(user2)
+        .unwrap();
+    assert_eq!(
+        vault.account(user2.to_owned()).unwrap(),
+        AccountResponse {
+            denom: OSMO.to_owned(),
+            bonded: Uint128::new(500),
+            free: Uint128::new(500),
+        }
+    );
+    assert_eq!(
+        app.app()
+            .wrap()
+            .query_balance(&vault.contract_addr, OSMO)
+            .unwrap(),
+        coin(800, OSMO)
+    );
+    assert_eq!(
+        app.app()
+            .wrap()
+            .query_balance(&cross_staking.contract_addr, OSMO)
+            .unwrap(),
+        coin(0, OSMO)
+    );
+
+    // No pending txs
+    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs, vec![]);
+
+    // Staking remotely
+
+    vault
+        .stake_remote(
+            cross_staking.contract_addr.to_string(),
+            coin(100, OSMO),
+            Binary::default(),
+        )
+        .call(user)
+        .unwrap();
+
+    // One pending tx
+    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs.len(), 1);
+
+    // Same user cannot stake while pending tx
+    assert_eq!(
+        vault
+            .stake_remote(
+                cross_staking.contract_addr.to_string(),
+                coin(100, OSMO),
+                Binary::default(),
+            )
+            .call(user)
+            .unwrap_err(),
+        ContractError::Lock(LockError::WriteLocked)
+    );
+    // Store for later
+    let first_tx = get_last_pending_tx_id(&vault).unwrap();
+
+    // But other user can
+    vault
+        .stake_remote(
+            cross_staking.contract_addr.to_string(),
+            coin(100, OSMO),
+            Binary::default(),
+        )
+        .call(user2)
+        .unwrap();
+
+    // Two pending txs
+    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs.len(), 2);
+
+    // Last tx commit_tx call
+    let last_tx = get_last_pending_tx_id(&vault).unwrap();
+    vault
+        .vault_api_proxy()
+        .commit_tx(last_tx)
+        .call(cross_staking.contract_addr.as_str())
+        .unwrap();
+
+    // First tx is still pending
+    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs[0].id, first_tx);
+
+    // Cannot query account while pending
+    assert!(matches!(vault.account(user.to_owned()).unwrap_err(),
+               ContractError::Std(GenericErr {..}))); // write locked
+    // Cannot query claims while pending
+    assert!(matches!(vault.account_claims(user.to_owned(), None, None).unwrap_err(),
+               ContractError::Std(GenericErr {..}))); // write locked
+
+    // Can query the other account
+    let acc = vault.account(user2.to_owned()).unwrap();
+    assert_eq!(
+        acc,
+        AccountResponse {
+            denom: OSMO.to_owned(),
+            bonded: Uint128::new(500),
+            free: Uint128::new(400),
+        }
+    );
+    // Can query the other account claims
+    let claims = vault.account_claims(user2.to_owned(), None, None).unwrap();
+    assert_eq!(
+        claims.claims,
+        [LienInfo {
+            lienholder: cross_staking.contract_addr.to_string(),
+            amount: Uint128::new(100)
+        }]
+    );
+
+    // Commit first tx
+    vault
+        .vault_api_proxy()
+        .commit_tx(first_tx)
+        .call(cross_staking.contract_addr.as_str())
+        .unwrap();
+
+    // Can query account now
+    let acc = vault.account(user.to_owned()).unwrap();
+    assert_eq!(
+        acc,
+        AccountResponse {
+            denom: OSMO.to_owned(),
+            bonded: Uint128::new(300),
+            free: Uint128::new(200),
+        }
+    );
+    // Can query claims
+    let claims = vault.account_claims(user.to_owned(), None, None).unwrap();
+    assert_eq!(
+        claims.claims,
+        [LienInfo {
+            lienholder: cross_staking.contract_addr.to_string(),
+            amount: Uint128::new(100)
+        }]
+    );
+    assert_eq!(
+        app.app()
+            .wrap()
+            .query_balance(&vault.contract_addr, OSMO)
+            .unwrap(),
+        coin(800, OSMO)
+    );
 }
 
 #[test]

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -448,7 +448,7 @@ fn stake_local() {
 
 #[track_caller]
 fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
-    let txs = vault.all_pending_txs(None, None).unwrap().txs;
+    let txs = vault.all_pending_txs_desc(None, None).unwrap().txs;
     txs.first().map(|tx| match tx {
         Tx::InFlightStaking { id, .. } => *id,
     })
@@ -827,7 +827,7 @@ fn stake_cross_txs() {
     );
 
     // No pending txs
-    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs, vec![]);
+    assert_eq!(vault.all_pending_txs_desc(None, None).unwrap().txs, vec![]);
     // Can query all accounts
     let accounts = vault.all_accounts(false, None, None).unwrap();
     assert_eq!(accounts.accounts.len(), 2);
@@ -844,7 +844,7 @@ fn stake_cross_txs() {
         .unwrap();
 
     // One pending tx
-    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs.len(), 1);
+    assert_eq!(vault.all_pending_txs_desc(None, None).unwrap().txs.len(), 1);
 
     // Same user cannot stake while pending tx
     assert_eq!(
@@ -872,7 +872,7 @@ fn stake_cross_txs() {
         .unwrap();
 
     // Two pending txs
-    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs.len(), 2);
+    assert_eq!(vault.all_pending_txs_desc(None, None).unwrap().txs.len(), 2);
 
     // Last tx commit_tx call
     let last_tx = get_last_pending_tx_id(&vault).unwrap();
@@ -883,7 +883,7 @@ fn stake_cross_txs() {
         .unwrap();
 
     // First tx is still pending
-    let first_id = match vault.all_pending_txs(None, None).unwrap().txs[0] {
+    let first_id = match vault.all_pending_txs_desc(None, None).unwrap().txs[0] {
         InFlightStaking { id, .. } => id,
     };
     assert_eq!(first_id, first_tx);
@@ -1041,7 +1041,7 @@ fn stake_cross_rollback_tx() {
         .unwrap();
 
     // One pending tx
-    assert_eq!(vault.all_pending_txs(None, None).unwrap().txs.len(), 1);
+    assert_eq!(vault.all_pending_txs_desc(None, None).unwrap().txs.len(), 1);
 
     // Rollback tx
     let last_tx = get_last_pending_tx_id(&vault).unwrap();
@@ -1052,7 +1052,11 @@ fn stake_cross_rollback_tx() {
         .unwrap();
 
     // No pending txs
-    assert!(vault.all_pending_txs(None, None).unwrap().txs.is_empty());
+    assert!(vault
+        .all_pending_txs_desc(None, None)
+        .unwrap()
+        .txs
+        .is_empty());
 
     // Funds are restored
     let acc = vault.account(user.to_owned()).unwrap();

--- a/contracts/provider/vault/src/multitest/cross_staking.rs
+++ b/contracts/provider/vault/src/multitest/cross_staking.rs
@@ -63,18 +63,13 @@ impl CrossStakingApi for CrossStaking<'_> {
     #[msg(exec)]
     fn receive_virtual_stake(
         &self,
-        ctx: ExecCtx,
+        _ctx: ExecCtx,
         _owner: String,
         _amount: Coin,
-        tx: u64,
+        _tx: u64,
         _msg: Binary,
     ) -> Result<Response, ContractError> {
-        let vault = ctx.info.sender;
-        let vault_api_helper = vault_api::VaultApiHelper(vault);
-        // TODO: Fail / rollback tx support
-        // FIXME: Shouldn't be sync
-        let msg = vault_api_helper.commit_tx(tx)?;
-        Ok(Response::new().add_message(msg))
+        Ok(Response::new())
     }
 
     #[msg(query)]

--- a/contracts/provider/vault/src/multitest/cross_staking.rs
+++ b/contracts/provider/vault/src/multitest/cross_staking.rs
@@ -66,6 +66,7 @@ impl CrossStakingApi for CrossStaking<'_> {
         _ctx: ExecCtx,
         _owner: String,
         _amount: Coin,
+        _tx: u64,
         _msg: Binary,
     ) -> Result<Response, ContractError> {
         Ok(Response::new())

--- a/contracts/provider/vault/src/multitest/cross_staking.rs
+++ b/contracts/provider/vault/src/multitest/cross_staking.rs
@@ -63,13 +63,18 @@ impl CrossStakingApi for CrossStaking<'_> {
     #[msg(exec)]
     fn receive_virtual_stake(
         &self,
-        _ctx: ExecCtx,
+        ctx: ExecCtx,
         _owner: String,
         _amount: Coin,
-        _tx: u64,
+        tx: u64,
         _msg: Binary,
     ) -> Result<Response, ContractError> {
-        Ok(Response::new())
+        let vault = ctx.info.sender;
+        let vault_api_helper = vault_api::VaultApiHelper(vault);
+        // TODO: Fail / rollback tx support
+        // FIXME: Shouldn't be sync
+        let msg = vault_api_helper.commit_tx(tx)?;
+        Ok(Response::new().add_message(msg))
     }
 
     #[msg(query)]

--- a/contracts/provider/vault/src/txs.rs
+++ b/contracts/provider/vault/src/txs.rs
@@ -1,0 +1,52 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Decimal, Uint128};
+use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
+
+#[cw_serde]
+pub enum TxType {
+    Stake,
+    Unstake,
+    // TODO
+    // Slash,
+}
+
+#[cw_serde]
+pub struct Tx {
+    /// Transaction type
+    pub ty: TxType,
+    /// Associated amount
+    pub amount: Uint128,
+    /// Slashable portion of lien
+    pub slashable: Decimal,
+    /// Associated user
+    pub user: Addr,
+    /// Remote staking contract
+    pub lienholder: Addr,
+}
+
+pub struct TxIndexes<'a> {
+    // Last type param defines the pk deserialization type
+    pub users: MultiIndex<'a, Addr, Tx, Addr>,
+}
+
+impl<'a> IndexList<Tx> for TxIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Tx>> + '_> {
+        let v: Vec<&dyn Index<Tx>> = vec![&self.users];
+        Box::new(v.into_iter())
+    }
+}
+
+pub struct Txs<'a> {
+    pub txs: IndexedMap<'a, u64, Tx, TxIndexes<'a>>,
+}
+
+impl<'a> Txs<'a> {
+    pub fn new(storage_key: &'a str, user_subkey: &'a str) -> Self {
+        let indexes = TxIndexes {
+            users: MultiIndex::new(|_, tx| tx.user.clone(), storage_key, user_subkey),
+        };
+        let txs = IndexedMap::new(storage_key, indexes);
+
+        Self { txs }
+    }
+}

--- a/contracts/provider/vault/src/txs.rs
+++ b/contracts/provider/vault/src/txs.rs
@@ -4,8 +4,7 @@ use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
 
 #[cw_serde]
 pub enum TxType {
-    Stake,
-    Unstake,
+    InFlightStaking,
     // TODO
     // Slash,
 }

--- a/packages/apis/src/cross_staking_api.rs
+++ b/packages/apis/src/cross_staking_api.rs
@@ -24,6 +24,7 @@ pub trait CrossStakingApi {
         ctx: ExecCtx,
         owner: String,
         amount: Coin,
+        tx_id: u64,
         msg: Binary,
     ) -> Result<Response, Self::Error>;
 
@@ -44,10 +45,16 @@ impl CrossStakingApiHelper {
         &self,
         owner: String,
         amount: Coin,
+        tx_id: u64,
         msg: Binary,
         funds: Vec<Coin>,
     ) -> Result<WasmMsg, StdError> {
-        let msg = CrossStakingApiExecMsg::ReceiveVirtualStake { owner, msg, amount };
+        let msg = CrossStakingApiExecMsg::ReceiveVirtualStake {
+            owner,
+            msg,
+            amount,
+            tx_id,
+        };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
             msg: to_binary(&msg)?,

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -29,6 +29,16 @@ pub trait VaultApi {
         // address of the user who originally called stake_remote
         owner: String,
     ) -> Result<Response, Self::Error>;
+
+    /// This must be called by the remote staking contract to commit the remote staking call on success.
+    /// Transaction ID is used to identify the original (vault contract originated) transaction.
+    #[msg(exec)]
+    fn commit_tx(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error>;
+
+    /// This must be called by the remote staking contract to rollback the remote staking call on failure.
+    /// Transaction ID is used to identify the original (vault contract originated) transaction.
+    #[msg(exec)]
+    fn rollback_tx(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error>;
 }
 
 #[cw_serde]

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -81,4 +81,24 @@ impl VaultApiHelper {
         };
         Ok(wasm)
     }
+
+    pub fn commit_tx(&self, tx_id: u64) -> Result<WasmMsg, StdError> {
+        let msg = VaultApiExecMsg::CommitTx { tx_id };
+        let wasm = WasmMsg::Execute {
+            contract_addr: self.0.to_string(),
+            msg: to_binary(&msg)?,
+            funds: vec![],
+        };
+        Ok(wasm)
+    }
+
+    pub fn rollback_tx(&self, tx_id: u64) -> Result<WasmMsg, StdError> {
+        let msg = VaultApiExecMsg::RollbackTx { tx_id };
+        let wasm = WasmMsg::Execute {
+            contract_addr: self.0.to_string(),
+            msg: to_binary(&msg)?,
+            funds: vec![],
+        };
+        Ok(wasm)
+    }
 }

--- a/packages/mocks/src/cross_staking.rs
+++ b/packages/mocks/src/cross_staking.rs
@@ -101,6 +101,7 @@ impl CrossStakingApi for MockCrossStakingContract<'_> {
         ctx: ExecCtx,
         owner: String,
         amount: Coin,
+        tx_id: u64,
         msg: Binary,
     ) -> Result<Response, Self::Error> {
         nonpayable(&ctx.info)?;
@@ -120,7 +121,7 @@ impl CrossStakingApi for MockCrossStakingContract<'_> {
         );
 
         // ignore args
-        let _ = (owner, msg, amount);
+        let _ = (owner, msg, amount, tx_id);
         Ok(Response::new())
     }
 

--- a/packages/mocks/src/vault.rs
+++ b/packages/mocks/src/vault.rs
@@ -229,4 +229,20 @@ impl VaultApi for MockVaultContract<'_> {
         // we don't track liens so no-op
         Ok(Response::new())
     }
+
+    /// This must be called by the remote staking contract to commit the remote staking call on success.
+    /// Transaction ID is used to identify the original (vault contract originated) transaction.
+    #[msg(exec)]
+    fn commit_tx(&self, _ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error> {
+        let _ = tx_id;
+        Ok(Response::new())
+    }
+
+    /// This must be called by the remote staking contract to rollback the remote staking call on failure.
+    /// Transaction ID is used to identify the original (vault contract originated) transaction.
+    #[msg(exec)]
+    fn rollback_tx(&self, _ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error> {
+        let _ = tx_id;
+        Ok(Response::new())
+    }
 }

--- a/packages/mocks/src/vault.rs
+++ b/packages/mocks/src/vault.rs
@@ -129,6 +129,8 @@ impl MockVaultContract<'_> {
         contract: String,
         // amount to stake on that contract
         amount: Coin,
+        // associated transaction id
+        tx_id: u64,
         // action to take with that stake
         msg: Binary,
     ) -> Result<Response, VaultError> {
@@ -139,6 +141,7 @@ impl MockVaultContract<'_> {
         let wasm_msg = cross_staking.receive_virtual_stake(
             ctx.info.sender.into_string(),
             amount,
+            tx_id,
             msg,
             vec![],
         )?;

--- a/packages/sync/src/lib.rs
+++ b/packages/sync/src/lib.rs
@@ -1,5 +1,7 @@
 mod locks;
 mod range;
+mod txs;
 
 pub use locks::{LockError, LockState, Lockable};
 pub use range::{max_range, min_range, spread, RangeError, ValueRange};
+pub use txs::Tx;

--- a/packages/sync/src/txs.rs
+++ b/packages/sync/src/txs.rs
@@ -1,0 +1,38 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Decimal, Uint128};
+use std::fmt::Formatter;
+
+#[cw_serde]
+pub enum Tx {
+    InFlightStaking {
+        /// Transaction id
+        id: u64,
+        /// Associated amount
+        amount: Uint128,
+        /// Slashable portion of lien
+        slashable: Decimal,
+        /// Associated user
+        user: Addr,
+        /// Remote staking contract
+        lienholder: Addr,
+    },
+    // TODO:
+    // InFlightSlashing
+}
+
+// Implement display for Tx
+impl std::fmt::Display for Tx {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Tx::InFlightStaking {
+                id,
+                amount,
+                slashable,
+                user,
+                lienholder,
+            } => {
+                write!(f, "InFlightStaking {{ id: {}, amount: {}, slashable: {}, user: {}, lienholder: {} }}", id, amount, slashable, user, lienholder)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Alternative to #54, but using `Lockable` for synchronisation.

Proves that `Lockable` is a useful abstraction around this.

TODO:

- [x] Send tx id in msg.
- [x] User info locking.
- [x] Commit / rollback msgs.
- [x] Adapt existing tests. 
- [x] Write tx-specific tests
  - [x] `commit_tx`.
  - [x] `rollback_tx`.
  - [x] In flight / collision.