### PR TITLE
Implement IBC Validator Sync sub-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "external-staking"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -553,7 +553,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mesh-apis"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-bindings"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-converter"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-mocks"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-native-staking"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-native-staking-proxy"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-simple-price-feed"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-sync"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-vault"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-virtual-staking"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition       = "2021"
-version       = "0.2.0"
+version       = "0.3.0-alpha.1"
 license       = "MIT"
 repository    = "https://github.com/osmosis-labs/mesh-security"
 

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -84,3 +84,6 @@ impl<'a> CrdtState<'a> {
         self.validators.save(storage, valoper, &state)
     }
 }
+
+#[cfg(test)]
+mod tests {}

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -1,0 +1,86 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{StdError, Storage};
+use cw_storage_plus::Map;
+
+#[cw_serde]
+pub enum ValidatorState {
+    Active(ActiveState),
+    Tombstoned {},
+}
+
+#[cw_serde]
+/// Active state maintains a sorted list of updates with no duplicates.
+/// The first one is the one with the highest start_height.
+pub struct ActiveState(Vec<ValUpdate>);
+
+impl ActiveState {
+    /// Add one more element to this list, maintaining the constraints
+    pub fn insert_unique(&mut self, update: ValUpdate) {
+        self.0.push(update);
+        self.0.sort_by(|a, b| b.start_height.cmp(&a.start_height));
+        self.0.dedup();
+    }
+}
+
+#[cw_serde]
+pub struct ValUpdate {
+    pub pub_key: String,
+    pub start_height: u64,
+    pub start_time: u64,
+}
+
+impl ValUpdate {
+    pub fn new(pub_key: impl Into<String>, start_height: u64, start_time: u64) -> Self {
+        ValUpdate {
+            pub_key: pub_key.into(),
+            start_height,
+            start_time,
+        }
+    }
+}
+
+/// This holds all CRDT related state and logic (related to validators)
+pub struct CrdtState<'a> {
+    validators: Map<'a, &'a str, ValidatorState>,
+}
+
+impl<'a> CrdtState<'a> {
+    pub const fn new() -> Self {
+        CrdtState {
+            validators: Map::new("crdt.validators"),
+        }
+    }
+
+    pub fn add_validator(
+        &self,
+        storage: &mut dyn Storage,
+        valoper: &str,
+        update: ValUpdate,
+    ) -> Result<(), StdError> {
+        let mut state = self
+            .validators
+            .may_load(storage, valoper)?
+            .unwrap_or_else(|| ValidatorState::Active(ActiveState(vec![])));
+
+        match &mut state {
+            ValidatorState::Active(active) => {
+                // add to the set, ensuring there are no duplicates
+                active.insert_unique(update);
+            }
+            ValidatorState::Tombstoned {} => {
+                // we just silently ignore it here
+            }
+        }
+
+        self.validators.save(storage, valoper, &state)
+    }
+
+    pub fn remove_validator(
+        &self,
+        storage: &mut dyn Storage,
+        valoper: &str,
+    ) -> Result<(), StdError> {
+        let state = ValidatorState::Tombstoned {};
+        self.validators.save(storage, valoper, &state)
+    }
+}

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -2,14 +2,14 @@
 use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
-    from_slice, to_binary, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
+    from_slice, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
     IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
 };
 use cw_storage_plus::Item;
 use mesh_apis::ibc::{
-    validate_channel_order, AddValidator, AddValidatorsAck, ConsumerPacket, ProtocolVersion,
-    RemoveValidatorsAck,
+    ack_success, validate_channel_order, AddValidator, AddValidatorsAck, ConsumerPacket,
+    ProtocolVersion, RemoveValidatorsAck,
 };
 
 use crate::{
@@ -132,13 +132,13 @@ pub fn ibc_packet_receive(
                 };
                 VAL_CRDT.add_validator(deps.storage, &valoper, update)?;
             }
-            to_binary(&AddValidatorsAck {})?
+            ack_success(&AddValidatorsAck {})?
         }
         ConsumerPacket::RemoveValidators(to_remove) => {
             for valoper in to_remove {
                 VAL_CRDT.remove_validator(deps.storage, &valoper)?;
             }
-            to_binary(&RemoveValidatorsAck {})?
+            ack_success(&RemoveValidatorsAck {})?
         }
     };
 

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -2,14 +2,21 @@
 use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
-    from_slice, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
+    from_slice, to_binary, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
     IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
 };
 use cw_storage_plus::Item;
-use mesh_apis::ibc::{validate_channel_order, ProtocolVersion};
+use mesh_apis::ibc::{
+    validate_channel_order, AddValidator, AddValidatorsAck, ConsumerPacket, ProtocolVersion,
+    RemoveValidatorsAck,
+};
 
-use crate::{error::ContractError, msg::AuthorizedEndpoint};
+use crate::{
+    crdt::{CrdtState, ValUpdate},
+    error::ContractError,
+    msg::AuthorizedEndpoint,
+};
 
 /// This is the maximum version of the Mesh Security protocol that we support
 const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "1.0.0";
@@ -21,6 +28,8 @@ pub const AUTH_ENDPOINT: Item<AuthorizedEndpoint> = Item::new("auth_endpoint");
 
 // TODO: expected endpoint
 pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
+
+pub const VAL_CRDT: CrdtState = CrdtState::new();
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 /// enforces ordering and versioning constraints
@@ -89,8 +98,6 @@ pub fn ibc_channel_connect(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-/// On closed channel, we take all tokens from reflect contract to this contract.
-/// We also delete the channel entry from accounts.
 pub fn ibc_channel_close(
     _deps: DepsMut,
     _env: Env,
@@ -100,15 +107,43 @@ pub fn ibc_channel_close(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-/// we look for a the proper reflect contract to relay to and send the message
-/// We cannot return any meaningful response value as we do not know the response value
-/// of execution. We just return ok if we dispatched, error if we failed to dispatch
+// this accepts validator sync packets and updates the crdt state
 pub fn ibc_packet_receive(
-    _deps: DepsMut,
+    deps: DepsMut,
     _env: Env,
-    _msg: IbcPacketReceiveMsg,
+    msg: IbcPacketReceiveMsg,
 ) -> Result<IbcReceiveResponse, ContractError> {
-    todo!();
+    // There is only one channel, so we don't need to switch.
+    // We also don't care about packet sequence as this is fully commutative.
+    let packet: ConsumerPacket = from_slice(&msg.packet.data)?;
+    let ack = match packet {
+        ConsumerPacket::AddValidators(to_add) => {
+            for AddValidator {
+                valoper,
+                pub_key,
+                start_height,
+                start_time,
+            } in to_add
+            {
+                let update = ValUpdate {
+                    pub_key,
+                    start_height,
+                    start_time,
+                };
+                VAL_CRDT.add_validator(deps.storage, &valoper, update)?;
+            }
+            to_binary(&AddValidatorsAck {})?
+        }
+        ConsumerPacket::RemoveValidators(to_remove) => {
+            for valoper in to_remove {
+                VAL_CRDT.remove_validator(deps.storage, &valoper)?;
+            }
+            to_binary(&RemoveValidatorsAck {})?
+        }
+    };
+
+    // return empty success ack
+    Ok(IbcReceiveResponse::new().set_ack(ack))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/provider/external-staking/src/lib.rs
+++ b/contracts/provider/external-staking/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod crdt;
 pub mod error;
 pub mod ibc;
 pub mod msg;

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -33,6 +33,11 @@ pub struct IbcChannelResponse {
     pub channel: IbcChannel,
 }
 
+#[cw_serde]
+pub struct ListRemoteValidatorsResponse {
+    pub validators: Vec<String>,
+}
+
 /// Config information returned with query
 #[cw_serde]
 pub struct ConfigResponse {

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -15,6 +15,8 @@ pub enum ProviderPacket {
         /// It will be converted to the consumer-side staking token in the converter with help
         /// of the price feed.
         stake: Coin,
+        /// This is local to the sending side to track the transaction, should be passed through opaquely on the consumer
+        tx_id: u64,
     },
     /// This should be called when we begin the unbonding period of some more tokens previously virtually staked
     Unstake {
@@ -23,16 +25,24 @@ pub enum ProviderPacket {
         /// It will be converted to the consumer-side staking token in the converter with help
         /// of the price feed.
         unstake: Coin,
+        /// This is local to the sending side to track the transaction, should be passed through opaquely on the consumer
+        tx_id: u64,
     },
 }
 
 /// Ack sent for ProviderPacket::Stake
 #[cw_serde]
-pub struct StakeAck {}
+pub struct StakeAck {
+    /// Return the value from the original packet
+    tx_id: u64,
+}
 
 /// Ack sent for ProviderPacket::Unstake
 #[cw_serde]
-pub struct UnstakeAck {}
+pub struct UnstakeAck {
+    /// Return the value from the original packet
+    tx_id: u64,
+}
 
 /// These are messages sent from consumer -> provider
 /// ibc_packet_receive in external-staking must handle them all.

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::Coin;
 /// ibc_packet_receive in converter must handle them all.
 /// Each one has a different ack to be used in the reply.
 #[cw_serde]
-pub enum ProviderMsg {
+pub enum ProviderPacket {
     /// This should be called when we lock more tokens to virtually stake on a given validator
     Stake {
         validator: String,
@@ -24,58 +24,52 @@ pub enum ProviderMsg {
     },
 }
 
-/// Ack sent for ProviderMsg::Stake
+/// Ack sent for ProviderPacket::Stake
 #[cw_serde]
 pub struct StakeAck {}
 
-/// Ack sent for ProviderMsg::Unstake
+/// Ack sent for ProviderPacket::Unstake
 #[cw_serde]
 pub struct UnstakeAck {}
 
 /// These are messages sent from consumer -> provider
 /// ibc_packet_receive in external-staking must handle them all.
 #[cw_serde]
-pub enum ConsumerMsg {
+pub enum ConsumerPacket {
     /// This is sent when a new validator registers and is available to receive
-    /// delegations.
-    /// This packet is sent right after the channel is opened to sync initial state
-    AddValidators(Vec<Validator>),
+    /// delegations. This is also sent when a validator changes pubkey.
+    /// One such packet is sent right after the channel is opened to sync initial state
+    AddValidators(Vec<AddValidator>),
     /// This is sent when a validator is tombstoned. Not just leaving the active state,
     /// but when it is no longer a valid target to delegate to.
     /// It contains a list of `valoper_address` to be removed
     RemoveValidators(Vec<String>),
-    /// This is sent a validator changes the pubkey
-    UpdatePubkey {
-        /// This is the validator address that is changing the pubkey
-        valoper_address: String,
-        /// This is the block height (on the consumer) at which the pubkey was changed
-        height: u64,
-        /// This is the pubkey signing all blocks after `height`
-        new_pubkey: String,
-        /// This is the pubkey signing all blocks up to and including `height`
-        old_pubkey: String,
-    },
 }
 
 #[cw_serde]
-pub struct Validator {
-    /// This is the validator address used for delegations and rewards
-    pub valoper_address: String,
+pub struct AddValidator {
+    /// This is the validator operator (valoper) address used for delegations and rewards
+    pub valoper: String,
 
     // TODO: is there a better type for this? what encoding is used
     /// This is the *Tendermint* public key, used for signing blocks.
     /// This is needed to detect slashing conditions
     pub pub_key: String,
+
+    /// This is the first height the validator was active.
+    /// It is used to detect slashing conditions, eg which header heights are punishable.
+    pub start_height: u64,
+
+    /// This is the timestamp of the first block the validator was active.
+    /// It may be used for unbonding_period issues, maybe just for informational purposes.
+    /// Stored as unix seconds.
+    pub start_time: u64,
 }
 
-/// Ack sent for ConsumerMsg::AddValidators
+/// Ack sent for ConsumerPacket::AddValidators
 #[cw_serde]
 pub struct AddValidatorsAck {}
 
-/// Ack sent for ConsumerMsg::RemoveValidators
+/// Ack sent for ConsumerPacket::RemoveValidators
 #[cw_serde]
 pub struct RemoveValidatorsAck {}
-
-/// Ack sent for ConsumerMsg::UpdatePubkey
-#[cw_serde]
-pub struct UpdatePubkeyAck {}


### PR DESCRIPTION
Send the validator sync packets from Consumer (`converter`) to Provider (`external-staking`) and process them into the CRDT type there.

Add tests on the CRDT and some queries, so we can (in a future PR) check validators before staking, or associate tendermint double-signs with valoper addresses (next milestone) 