### PR TITLE
Add ibc handling to converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "cw2",
  "derivative",
  "mesh-apis",
+ "mesh-simple-price-feed",
  "schemars",
  "serde",
  "sylvia",

--- a/contracts/consumer/converter/Cargo.toml
+++ b/contracts/consumer/converter/Cargo.toml
@@ -34,6 +34,8 @@ serde            = { workspace = true }
 thiserror        = { workspace = true }
 
 [dev-dependencies]
+mesh-simple-price-feed = { workspace = true, features = ["mt"] }
+
 cw-multi-test = { workspace = true }
 test-case     = { workspace = true }
 derivative    = { workspace = true }

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -19,6 +19,10 @@ use crate::state::Config;
 pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+// TODO: remove need for this
+// This is used to gate the test functions that trigger IBC logic
+pub const FAKE_IBC: &str = "ADMIN";
+
 const REPLY_ID_INSTANTIATE: u64 = 1;
 
 pub struct ConverterContract<'a> {

--- a/contracts/consumer/converter/src/error.rs
+++ b/contracts/consumer/converter/src/error.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::StdError;
-use cw_utils::PaymentError;
+use cw_utils::{ParseReplyError, PaymentError};
 use mesh_apis::ibc::VersionError;
 use thiserror::Error;
 
@@ -14,6 +14,9 @@ pub enum ContractError {
     #[error("{0}")]
     IbcVersion(#[from] VersionError),
 
+    #[error("{0}")]
+    ParseReply(#[from] ParseReplyError),
+
     #[error("Unauthorized")]
     Unauthorized,
 
@@ -25,4 +28,7 @@ pub enum ContractError {
 
     #[error("Sent wrong denom over IBC: {sent}, expected {expected}")]
     WrongDenom { sent: String, expected: String },
+
+    #[error("Invalid reply id: {0}")]
+    InvalidReplyId(u64),
 }

--- a/contracts/consumer/converter/src/error.rs
+++ b/contracts/consumer/converter/src/error.rs
@@ -22,4 +22,7 @@ pub enum ContractError {
 
     #[error("You must start the channel handshake on this side, it doesn't support OpenTry")]
     IbcOpenTryDisallowed,
+
+    #[error("Sent wrong denom over IBC: {sent}, expected {expected}")]
+    WrongDenom { sent: String, expected: String },
 }

--- a/contracts/consumer/converter/src/lib.rs
+++ b/contracts/consumer/converter/src/lib.rs
@@ -2,4 +2,6 @@ pub mod contract;
 pub mod error;
 pub mod ibc;
 pub mod msg;
+#[cfg(test)]
+mod multitest;
 pub mod state;

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -1,1 +1,135 @@
-mod virtual_staking;
+mod virtual_staking_mock;
+
+use cosmwasm_std::{Addr, Decimal};
+
+use sylvia::multitest::App;
+
+use crate::contract;
+// use crate::error::ContractError;
+// use crate::msg;
+
+const JUNO: &str = "ujuno";
+
+#[test]
+fn instantiation() {
+    let app = App::default();
+
+    let owner = "Sunny"; // Owner of the staking contract (i. e. the vault contract)
+    let admin = "The man";
+    let discount = Decimal::percent(40); // 1 OSMO worth of JUNO should give 0.6 OSMO of stake
+    let native_per_foreign = Decimal::percent(50); // 1 JUNO is worth 0.5 OSMO
+
+    let price_feed_code =
+        mesh_simple_price_feed::contract::multitest_utils::CodeId::store_code(&app);
+    let virtual_staking_code = virtual_staking_mock::multitest_utils::CodeId::store_code(&app);
+    let converter_code = contract::multitest_utils::CodeId::store_code(&app);
+
+    let price_feed = price_feed_code
+        .instantiate(native_per_foreign, None)
+        .with_label("Price Feed")
+        .call(owner)
+        .unwrap();
+
+    let converter = converter_code
+        .instantiate(
+            price_feed.contract_addr.to_string(),
+            discount,
+            JUNO.to_owned(),
+            virtual_staking_code.code_id(),
+        )
+        .with_label("Juno Converter")
+        .with_admin(admin)
+        .call(owner)
+        .unwrap();
+
+    // check the config
+    let config = converter.config().unwrap();
+    assert_eq!(config.price_feed, price_feed.contract_addr.to_string());
+    assert_eq!(config.adjustment, Decimal::percent(60));
+    assert!(!config.virtual_staking.is_empty());
+
+    // let's check we passed the admin here properly
+    let vs_info = app
+        .app()
+        .wrap()
+        .query_wasm_contract_info(&config.virtual_staking)
+        .unwrap();
+    assert_eq!(vs_info.admin, Some(admin.to_string()));
+
+    // let's query virtual staking to find the owner
+    let virtual_staking_addr = Addr::unchecked(&config.virtual_staking);
+    let virtual_staking = virtual_staking_mock::multitest_utils::VirtualStakingMockProxy::new(
+        virtual_staking_addr,
+        &app,
+    );
+    let vs_config = virtual_staking.config().unwrap();
+    assert_eq!(vs_config.converter, converter.contract_addr.to_string());
+}
+
+/*
+#[test]
+fn receiving_stake() {
+    let owner = "vault"; // Owner of the staking contract (i. e. the vault contract)
+
+    let user1 = "user1"; // One who wants to local stake
+    let user2 = "user2"; // Another one who wants to local stake
+
+    let validator = "validator1"; // Validator to stake on
+
+    // Fund the vault
+    let app = MtApp::new(|router, _api, storage| {
+        router
+            .bank
+            .init_balance(storage, &Addr::unchecked(owner), coins(300, OSMO))
+            .unwrap();
+    });
+    let app = App::new(app);
+
+    // Contracts setup
+    let staking_proxy_code = local_staking_proxy::multitest_utils::CodeId::store_code(&app);
+    let staking_code = contract::multitest_utils::CodeId::store_code(&app);
+
+    let staking = staking_code
+        .instantiate(OSMO.to_owned(), staking_proxy_code.code_id())
+        .with_label("Staking")
+        .call(owner)
+        .unwrap();
+
+    // Check that no proxy exists for user1 yet
+    let err = staking.proxy_by_owner(user1.to_owned()).unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::Std(StdError::GenericErr { .. }) // Addr not found
+    ));
+
+    // Receive some stake on behalf of user1 for validator
+    let stake_msg = to_binary(&msg::StakeMsg {
+        validator: validator.to_owned(),
+    })
+    .unwrap();
+    staking
+        .local_staking_api_proxy()
+        .receive_stake(user1.to_owned(), stake_msg)
+        .with_funds(&coins(100, OSMO))
+        .call(owner) // called from vault
+        .unwrap();
+
+    let proxy1 = staking.proxy_by_owner(user1.to_owned()).unwrap().proxy;
+    // Reverse query
+    assert_eq!(
+        staking.owner_by_proxy(proxy1.clone()).unwrap(),
+        OwnerByProxyResponse {
+            owner: user1.to_owned(),
+        }
+    );
+
+    // Check that funds are in the proxy contract
+    assert_eq!(
+        app.app()
+            .wrap()
+            .query_balance(proxy1.clone(), OSMO)
+            .unwrap(),
+        coin(100, OSMO)
+    );
+}
+*/

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -1,0 +1,1 @@
+mod virtual_staking;

--- a/contracts/consumer/converter/src/multitest/virtual_staking.rs
+++ b/contracts/consumer/converter/src/multitest/virtual_staking.rs
@@ -1,0 +1,147 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{ensure_eq, Addr, Coin, Response, StdError, StdResult, Uint128};
+
+use cw_storage_plus::{Item, Map};
+use cw_utils::{nonpayable, PaymentError};
+use mesh_apis::virtual_staking_api::{self, VirtualStakingApi};
+use sylvia::contract;
+use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
+
+#[cw_serde]
+pub struct Config {
+    /// The denom we accept for staking
+    pub denom: String,
+    /// The address of the converter contract (that is authorized to bond/unbond and will receive rewards)
+    pub converter: Addr,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Wrong denom. Cannot stake {0}")]
+    WrongDenom(String),
+}
+
+/// This is a stub implementation of the local staking proxy contract, for test purposes only.
+/// When proper local staking proxy contract is available, this should be replaced in multitests
+pub struct VirtualStakingMock<'a> {
+    config: Item<'a, Config>,
+    stake: Map<'a, &'a str, Uint128>,
+}
+
+#[contract]
+#[error(ContractError)]
+#[messages(virtual_staking_api as VirtualStakingApi)]
+impl VirtualStakingMock<'_> {
+    pub const fn new() -> Self {
+        Self {
+            config: Item::new("config"),
+            stake: Map::new("stake"),
+        }
+    }
+
+    #[msg(instantiate)]
+    pub fn instantiate(&self, ctx: InstantiateCtx) -> Result<Response, ContractError> {
+        nonpayable(&ctx.info)?;
+        let denom = ctx.deps.querier.query_bonded_denom()?;
+        let config = Config {
+            denom,
+            converter: ctx.info.sender,
+        };
+        self.config.save(ctx.deps.storage, &config)?;
+        Ok(Response::new())
+    }
+
+    #[msg(query)]
+    fn stake(&self, ctx: QueryCtx, validator: String) -> Result<StakeResponse, ContractError> {
+        let stake = self
+            .stake
+            .may_load(ctx.deps.storage, &validator)?
+            .unwrap_or_default();
+        Ok(StakeResponse { stake })
+    }
+
+    #[msg(query)]
+    fn all_stake(&self, ctx: QueryCtx) -> Result<AllStakeResponse, ContractError> {
+        let stakes = self
+            .stake
+            .range(ctx.deps.storage, None, None, cosmwasm_std::Order::Ascending)
+            .collect::<StdResult<_>>()?;
+        Ok(AllStakeResponse { stakes })
+    }
+}
+
+#[cw_serde]
+pub struct StakeResponse {
+    pub stake: Uint128,
+}
+
+#[cw_serde]
+pub struct AllStakeResponse {
+    pub stakes: Vec<(String, Uint128)>,
+}
+
+#[contract]
+#[messages(virtual_staking_api as VirtualStakingApi)]
+impl VirtualStakingApi for VirtualStakingMock<'_> {
+    type Error = ContractError;
+
+    /// Requests to bond tokens to a validator. This will be actually handled at the next epoch.
+    /// If the virtual staking module is over the max cap, it will trigger a rebalance.
+    /// If the max cap is 0, then this will immediately return an error.
+    #[msg(exec)]
+    fn bond(&self, ctx: ExecCtx, validator: String, amount: Coin) -> Result<Response, Self::Error> {
+        nonpayable(&ctx.info)?;
+        let cfg = self.config.load(ctx.deps.storage)?;
+        ensure_eq!(ctx.info.sender, cfg.converter, ContractError::Unauthorized); // only the converter can call this
+        ensure_eq!(
+            amount.denom,
+            cfg.denom,
+            ContractError::WrongDenom(cfg.denom)
+        );
+
+        // Update the amount requested
+        self.stake
+            .update::<_, ContractError>(ctx.deps.storage, &validator, |old| {
+                Ok(old.unwrap_or_default() + amount.amount)
+            })?;
+
+        Ok(Response::new())
+    }
+
+    /// Requests to unbond tokens from a validator. This will be actually handled at the next epoch.
+    /// If the virtual staking module is over the max cap, it will trigger a rebalance in addition to unbond.
+    /// If the virtual staking contract doesn't have at least amont tokens staked to the given validator, this will return an error.
+    #[msg(exec)]
+    fn unbond(
+        &self,
+        ctx: ExecCtx,
+        validator: String,
+        amount: Coin,
+    ) -> Result<Response, Self::Error> {
+        nonpayable(&ctx.info)?;
+        let cfg = self.config.load(ctx.deps.storage)?;
+        ensure_eq!(ctx.info.sender, cfg.converter, ContractError::Unauthorized); // only the converter can call this
+        ensure_eq!(
+            amount.denom,
+            cfg.denom,
+            ContractError::WrongDenom(cfg.denom)
+        );
+
+        // Update the amount requested
+        self.stake
+            .update::<_, ContractError>(ctx.deps.storage, &validator, |old| {
+                Ok(old.unwrap_or_default() - amount.amount)
+            })?;
+
+        Ok(Response::new())
+    }
+}

--- a/contracts/consumer/converter/src/multitest/virtual_staking_mock.rs
+++ b/contracts/consumer/converter/src/multitest/virtual_staking_mock.rs
@@ -61,6 +61,14 @@ impl VirtualStakingMock<'_> {
     }
 
     #[msg(query)]
+    fn config(&self, ctx: QueryCtx) -> Result<ConfigResponse, ContractError> {
+        let cfg = self.config.load(ctx.deps.storage)?;
+        let denom = cfg.denom;
+        let converter = cfg.converter.into_string();
+        Ok(ConfigResponse { denom, converter })
+    }
+
+    #[msg(query)]
     fn stake(&self, ctx: QueryCtx, validator: String) -> Result<StakeResponse, ContractError> {
         let stake = self
             .stake
@@ -87,6 +95,12 @@ pub struct StakeResponse {
 #[cw_serde]
 pub struct AllStakeResponse {
     pub stakes: Vec<(String, Uint128)>,
+}
+
+#[cw_serde]
+pub struct ConfigResponse {
+    pub denom: String,
+    pub converter: String,
 }
 
 #[contract]

--- a/contracts/consumer/converter/src/state.rs
+++ b/contracts/consumer/converter/src/state.rs
@@ -12,4 +12,8 @@ pub struct Config {
 
     /// Address of the contract we query for the price feed to normalize the foreign asset into native tokens.
     pub price_feed: Addr,
+
+    /// Staking denom used on this chain
+    pub local_denom: String,
+    // TODO: expected remote denom for virtual staking
 }

--- a/contracts/consumer/converter/src/state.rs
+++ b/contracts/consumer/converter/src/state.rs
@@ -15,5 +15,8 @@ pub struct Config {
 
     /// Staking denom used on this chain
     pub local_denom: String,
-    // TODO: expected remote denom for virtual staking
+
+    /// Token being "virtually sent" over IBC.
+    /// use remote via, eg "uosmo", not "ibc/4EF183..."
+    pub remote_denom: String,
 }

--- a/contracts/consumer/converter/src/state.rs
+++ b/contracts/consumer/converter/src/state.rs
@@ -8,7 +8,7 @@ pub struct Config {
     /// Adjustment of 0.0 means the foreign asset has no value.
     /// Adjustment of 0.4 means the foreign asset has 40% of value after conversion.
     /// Note this is (1.0 - discount)
-    pub adjustment: Decimal,
+    pub price_adjustment: Decimal,
 
     /// Address of the contract we query for the price feed to normalize the foreign asset into native tokens.
     pub price_feed: Addr,

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -53,12 +53,9 @@ impl VirtualStakingContract<'_> {
 
     /// The caller of the instantiation will be the converter contract
     #[msg(instantiate)]
-    pub fn instantiate(
-        &self,
-        ctx: InstantiateCtx,
-        denom: String,
-    ) -> Result<Response, ContractError> {
+    pub fn instantiate(&self, ctx: InstantiateCtx) -> Result<Response, ContractError> {
         nonpayable(&ctx.info)?;
+        let denom = ctx.deps.querier.query_bonded_denom()?;
         let config = Config {
             denom,
             converter: ctx.info.sender,

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -34,14 +34,14 @@ pub enum ProviderPacket {
 #[cw_serde]
 pub struct StakeAck {
     /// Return the value from the original packet
-    tx_id: u64,
+    pub tx_id: u64,
 }
 
 /// Ack sent for ProviderPacket::Unstake
 #[cw_serde]
 pub struct UnstakeAck {
     /// Return the value from the original packet
-    tx_id: u64,
+    pub tx_id: u64,
 }
 
 /// These are messages sent from consumer -> provider


### PR DESCRIPTION
(Currently untested)

- [x] Add ibc_packet_receive with price normalization and calling the virtual staking contract.
- [x] Add remote denom to the instantiate entry point
- [x] Solve converter / virtual_staking "chicken and egg" problem (see [ConverterContract::instantiate](https://github.com/osmosis-labs/mesh-security/blob/consumer-side-ibc-staking/contracts/consumer/converter/src/contract.rs#L36-L42))
- [x] Add ~~sudo entry point~~ test ExecMsg variants to allow testing
- [x] Write simple multi-test to test this