### PR TITLE
Add Locked enum to vault account query

### DIFF
--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -19,9 +19,9 @@ use sylvia::{contract, schemars};
 use crate::error::ContractError;
 use crate::msg;
 use crate::msg::{
-    AccountClaimsResponse, AccountResponse, AllAccountsResponse, AllAccountsResponseItem,
-    AllTxsResponse, AllTxsResponseItem, ConfigResponse, LienInfo, MaybeAccountResponse,
-    StakingInitInfo, TxResponse,
+    AccountClaimsResponse, AllAccountsResponse, AllAccountsResponseItem, AllTxsResponse,
+    AllTxsResponseItem, ConfigResponse, LienInfo, MaybeAccountResponse, StakingInitInfo,
+    TxResponse,
 };
 use crate::state::{Config, Lien, LocalStaking, UserInfo};
 use crate::txs::Txs;
@@ -269,11 +269,11 @@ impl VaultContract<'_> {
             .may_load(ctx.deps.storage, &account)?
             .unwrap_or_default();
         match user_lock.read() {
-            Ok(user_info) => Ok(MaybeAccountResponse::Account(AccountResponse {
-                denom,
-                bonded: user_info.collateral,
-                free: user_info.free_collateral(),
-            })),
+            Ok(user_info) => Ok(MaybeAccountResponse::new_unlocked(
+                &denom,
+                user_info.collateral,
+                user_info.free_collateral(),
+            )),
             Err(_) => Ok(msg::MaybeAccountResponse::Locked {}),
         }
     }
@@ -383,11 +383,11 @@ impl VaultContract<'_> {
                 account.map(|(addr, account_lock)| match account_lock.read() {
                     Ok(user_info) => Ok(AllAccountsResponseItem {
                         user: addr.to_string(),
-                        account: MaybeAccountResponse::Account(AccountResponse {
-                            denom: denom.clone(),
-                            bonded: user_info.collateral,
-                            free: user_info.free_collateral(),
-                        }),
+                        account: MaybeAccountResponse::new_unlocked(
+                            &denom,
+                            user_info.collateral,
+                            user_info.free_collateral(),
+                        ),
                     }),
                     Err(_) => Ok(msg::AllAccountsResponseItem {
                         user: addr.to_string(),

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -17,10 +17,11 @@ use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx, ReplyCtx};
 use sylvia::{contract, schemars};
 
 use crate::error::ContractError;
+use crate::msg;
 use crate::msg::{
-    AccountClaimsResponse, AccountResponse, AllAccountsResponse, AllAccountsResponseItem,
-    AllTxsResponse, AllTxsResponseItem, ConfigResponse, LienInfo, StakingInitInfo, TxResponse,
-    UnlockedAccountResponse,
+    AccountClaimsResponse, AccountResponse, AllAccountsResponse, AllTxsResponse,
+    AllTxsResponseItem, ConfigResponse, LienInfo, MaybeAccountResponse, StakingInitInfo,
+    TxResponse,
 };
 use crate::state::{Config, Lien, LocalStaking, UserInfo};
 use crate::txs::Txs;
@@ -255,7 +256,11 @@ impl VaultContract<'_> {
     }
 
     #[msg(query)]
-    fn account(&self, ctx: QueryCtx, account: String) -> Result<AccountResponse, ContractError> {
+    fn account(
+        &self,
+        ctx: QueryCtx,
+        account: String,
+    ) -> Result<MaybeAccountResponse, ContractError> {
         let denom = self.config.load(ctx.deps.storage)?.denom;
         let account = ctx.deps.api.addr_validate(&account)?;
 
@@ -263,18 +268,17 @@ impl VaultContract<'_> {
             .users
             .may_load(ctx.deps.storage, &account)?
             .unwrap_or_default();
-        let user = match user_lock.read() {
-            Ok(user) => user,
-            Err(_) => return Ok(AccountResponse::Locked {}),
-        };
-
-        let resp = AccountResponse::Unlocked(UnlockedAccountResponse {
-            denom,
-            bonded: user.collateral,
-            free: user.free_collateral(),
-        });
-
-        Ok(resp)
+        match user_lock.read() {
+            Ok(user_info) => Ok(MaybeAccountResponse::Account(AccountResponse {
+                user: account.to_string(),
+                denom,
+                bonded: user_info.collateral,
+                free: user_info.free_collateral(),
+            })),
+            Err(_) => Ok(msg::MaybeAccountResponse::Locked {
+                user: account.to_string(),
+            }),
+        }
     }
 
     #[msg(query)]
@@ -374,21 +378,21 @@ impl VaultContract<'_> {
                         account_lock
                             .read()
                             .map(|account| !with_collateral || !account.collateral.is_zero()) // Skip zero collateral
-                            // FIXME: Don't skip write-locked accounts (map to `MaybeAccount` wrapper)
-                            .unwrap_or(false) // Skip write-locked accounts
+                            .unwrap_or(true)
                     })
                     .unwrap_or(false) // Skip other errors
             })
             .map(|account| {
-                account.map(|(addr, account_lock)| {
-                    account_lock.read().map(|account| {
-                        Ok(AllAccountsResponseItem {
-                            account: addr.into(),
-                            denom: denom.clone(),
-                            bonded: account.collateral,
-                            free: account.free_collateral(),
-                        })
-                    })?
+                account.map(|(addr, account_lock)| match account_lock.read() {
+                    Ok(user_info) => Ok(MaybeAccountResponse::Account(AccountResponse {
+                        user: addr.to_string(),
+                        denom: denom.clone(),
+                        bonded: user_info.collateral,
+                        free: user_info.free_collateral(),
+                    })),
+                    Err(_) => Ok(msg::MaybeAccountResponse::Locked {
+                        user: addr.to_string(),
+                    }),
                 })?
             })
             .take(limit)

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -274,9 +274,7 @@ impl VaultContract<'_> {
                 bonded: user_info.collateral,
                 free: user_info.free_collateral(),
             })),
-            Err(_) => Ok(msg::MaybeAccountResponse::Locked {
-                user: account.to_string(),
-            }),
+            Err(_) => Ok(msg::MaybeAccountResponse::Locked {}),
         }
     }
 
@@ -393,9 +391,7 @@ impl VaultContract<'_> {
                     }),
                     Err(_) => Ok(msg::AllAccountsResponseItem {
                         user: addr.to_string(),
-                        account: MaybeAccountResponse::Locked {
-                            user: addr.to_string(),
-                        },
+                        account: MaybeAccountResponse::Locked {},
                     }),
                 })?
             })

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -23,6 +23,13 @@ pub enum MaybeAccountResponse {
 }
 
 impl MaybeAccountResponse {
+    pub fn new_unlocked(denom: &str, bonded: Uint128, free: Uint128) -> Self {
+        Account(AccountResponse {
+            denom: denom.to_owned(),
+            bonded,
+            free,
+        })
+    }
     /// Designed for test code, unwrap or panic if Locked
     pub fn unwrap(self) -> AccountResponse {
         match self {

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -1,3 +1,4 @@
+use crate::msg::MaybeAccountResponse::{Account, Locked};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Binary, Uint128};
 use mesh_sync::Tx;
@@ -16,23 +17,24 @@ pub struct StakingInitInfo {
 }
 
 #[cw_serde]
-pub enum AccountResponse {
-    Unlocked(UnlockedAccountResponse),
-    Locked {},
+pub enum MaybeAccountResponse {
+    Account(AccountResponse),
+    Locked { user: String },
 }
 
-impl AccountResponse {
-    /// Designed for test code, unwrap the Unlocked variant or panic
-    pub fn unlocked(self) -> UnlockedAccountResponse {
+impl MaybeAccountResponse {
+    /// Designed for test code, unwrap or panic if Locked
+    pub fn unwrap(self) -> AccountResponse {
         match self {
-            AccountResponse::Unlocked(acct) => acct,
-            _ => panic!("AccountResponse was locked"),
+            Account(acct) => acct,
+            Locked { user } => panic!("AccountResponse for {user} is locked"),
         }
     }
 }
 
 #[cw_serde]
-pub struct UnlockedAccountResponse {
+pub struct AccountResponse {
+    pub user: String,
     // Everything is denom, changing all Uint128 to coin with the same denom seems very inefficient
     pub denom: String,
     pub bonded: Uint128,
@@ -41,17 +43,7 @@ pub struct UnlockedAccountResponse {
 
 #[cw_serde]
 pub struct AllAccountsResponse {
-    pub accounts: Vec<AllAccountsResponseItem>,
-}
-
-#[cw_serde]
-pub struct AllAccountsResponseItem {
-    pub account: String,
-    // TODO: embed AccountResponse here
-    // Everything is denom, changing all Uint128 to coin with the same denom seems very inefficient
-    pub denom: String,
-    pub bonded: Uint128,
-    pub free: Uint128,
+    pub accounts: Vec<MaybeAccountResponse>,
 }
 
 #[cw_serde]

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -16,7 +16,23 @@ pub struct StakingInitInfo {
 }
 
 #[cw_serde]
-pub struct AccountResponse {
+pub enum AccountResponse {
+    Unlocked(UnlockedAccountResponse),
+    Locked {},
+}
+
+impl AccountResponse {
+    /// Designed for test code, unwrap the Unlocked variant or panic
+    pub fn unlocked(self) -> UnlockedAccountResponse {
+        match self {
+            AccountResponse::Unlocked(acct) => acct,
+            _ => panic!("AccountResponse was locked"),
+        }
+    }
+}
+
+#[cw_serde]
+pub struct UnlockedAccountResponse {
     // Everything is denom, changing all Uint128 to coin with the same denom seems very inefficient
     pub denom: String,
     pub bonded: Uint128,
@@ -31,6 +47,7 @@ pub struct AllAccountsResponse {
 #[cw_serde]
 pub struct AllAccountsResponseItem {
     pub account: String,
+    // TODO: embed AccountResponse here
     // Everything is denom, changing all Uint128 to coin with the same denom seems very inefficient
     pub denom: String,
     pub bonded: Uint128,

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -55,6 +55,7 @@ pub struct AllAccountsResponse {
 #[cw_serde]
 pub struct AllAccountsResponseItem {
     pub user: String,
+    #[serde(flatten)]
     pub account: MaybeAccountResponse,
 }
 

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -19,7 +19,7 @@ pub struct StakingInitInfo {
 #[cw_serde]
 pub enum MaybeAccountResponse {
     Account(AccountResponse),
-    Locked { user: String },
+    Locked {},
 }
 
 impl MaybeAccountResponse {
@@ -27,7 +27,7 @@ impl MaybeAccountResponse {
     pub fn unwrap(self) -> AccountResponse {
         match self {
             Account(acct) => acct,
-            Locked { user } => panic!("AccountResponse for {user} is locked"),
+            Locked {} => panic!("Account is locked"),
         }
     }
 }

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -55,7 +55,6 @@ pub struct AllAccountsResponse {
 #[cw_serde]
 pub struct AllAccountsResponseItem {
     pub user: String,
-    #[serde(flatten)]
     pub account: MaybeAccountResponse,
 }
 

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -34,7 +34,6 @@ impl MaybeAccountResponse {
 
 #[cw_serde]
 pub struct AccountResponse {
-    pub user: String,
     // Everything is denom, changing all Uint128 to coin with the same denom seems very inefficient
     pub denom: String,
     pub bonded: Uint128,
@@ -43,7 +42,13 @@ pub struct AccountResponse {
 
 #[cw_serde]
 pub struct AllAccountsResponse {
-    pub accounts: Vec<MaybeAccountResponse>,
+    pub accounts: Vec<AllAccountsResponseItem>,
+}
+
+#[cw_serde]
+pub struct AllAccountsResponseItem {
+    pub user: String,
+    pub account: MaybeAccountResponse,
 }
 
 #[cw_serde]

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -1,11 +1,13 @@
 mod cross_staking;
 mod local_staking;
 
+use crate::contract;
 use crate::contract::multitest_utils::VaultContractProxy;
 use crate::contract::test_utils::VaultApi;
 use crate::error::ContractError;
-use crate::msg::{AllAccountsResponseItem, LienInfo, StakingInitInfo};
-use crate::{contract, msg::AccountResponse};
+use crate::msg::{
+    AccountResponse, AllAccountsResponseItem, LienInfo, StakingInitInfo, UnlockedAccountResponse,
+};
 use cosmwasm_std::StdError::GenericErr;
 use cosmwasm_std::{coin, coins, to_binary, Addr, Binary, Decimal, Empty, Uint128};
 use cw_multi_test::App as MtApp;
@@ -76,8 +78,8 @@ fn bonding() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::zero(),
             free: Uint128::zero(),
@@ -94,8 +96,8 @@ fn bonding() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(100),
             free: Uint128::new(100),
@@ -122,8 +124,8 @@ fn bonding() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(250),
             free: Uint128::new(250),
@@ -147,8 +149,8 @@ fn bonding() {
 
     vault.unbond(coin(200, OSMO)).call(user).unwrap();
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(50),
             free: Uint128::new(50),
@@ -170,8 +172,8 @@ fn bonding() {
 
     vault.unbond(coin(20, OSMO)).call(user).unwrap();
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(30),
             free: Uint128::new(30),
@@ -240,8 +242,8 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -272,8 +274,8 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -308,8 +310,8 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(50),
@@ -364,8 +366,8 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(100),
@@ -403,8 +405,8 @@ fn stake_local() {
         .call(owner)
         .unwrap();
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -502,8 +504,8 @@ fn stake_cross() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -545,10 +547,10 @@ fn stake_cross() {
         .call(cross_staking.contract_addr.as_str())
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap();
+    let acc = vault.account(user.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -591,10 +593,10 @@ fn stake_cross() {
         .call(cross_staking.contract_addr.as_str())
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap();
+    let acc = vault.account(user.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(50),
@@ -652,10 +654,10 @@ fn stake_cross() {
         .call(owner)
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap();
+    let acc = vault.account(user.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(100),
@@ -693,10 +695,10 @@ fn stake_cross() {
         .call(owner)
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap();
+    let acc = vault.account(user.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -790,8 +792,8 @@ fn stake_cross_txs() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -806,8 +808,8 @@ fn stake_cross_txs() {
         .call(user2)
         .unwrap();
     assert_eq!(
-        vault.account(user2.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user2.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(500),
             free: Uint128::new(500),
@@ -892,11 +894,12 @@ fn stake_cross_txs() {
     assert_eq!(first_id, first_tx);
 
     // Cannot query account while pending
-    assert!(matches!(
-        vault.account(user.to_owned()).unwrap_err(),
-        ContractError::Std(GenericErr { .. })
-    )); // write locked
-        // Cannot query claims while pending
+    assert_eq!(
+        vault.account(user.to_owned()).unwrap(),
+        AccountResponse::Locked {}
+    ); // write locked
+       // Cannot query claims while pending
+       // TODO: locked enum not error
     assert!(matches!(
         vault
             .account_claims(user.to_owned(), None, None)
@@ -924,10 +927,10 @@ fn stake_cross_txs() {
     );
 
     // Can query the other account
-    let acc = vault.account(user2.to_owned()).unwrap();
+    let acc = vault.account(user2.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(500),
             free: Uint128::new(400),
@@ -951,10 +954,10 @@ fn stake_cross_txs() {
         .unwrap();
 
     // Can query account now
-    let acc = vault.account(user.to_owned()).unwrap();
+    let acc = vault.account(user.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -1024,8 +1027,8 @@ fn stake_cross_rollback_tx() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -1062,10 +1065,10 @@ fn stake_cross_rollback_tx() {
         .is_empty());
 
     // Funds are restored
-    let acc = vault.account(user.to_owned()).unwrap();
+    let acc = vault.account(user.to_owned()).unwrap().unlocked();
     assert_eq!(
         acc,
-        AccountResponse {
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -1183,8 +1186,8 @@ fn multiple_stakes() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(1000),
             free: Uint128::new(700),
@@ -1244,8 +1247,8 @@ fn multiple_stakes() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap(),
-        AccountResponse {
+        vault.account(user.to_owned()).unwrap().unlocked(),
+        UnlockedAccountResponse {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(1000),
             free: Uint128::new(430),

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -5,7 +5,9 @@ use crate::contract;
 use crate::contract::multitest_utils::VaultContractProxy;
 use crate::contract::test_utils::VaultApi;
 use crate::error::ContractError;
-use crate::msg::{AccountResponse, LienInfo, MaybeAccountResponse, StakingInitInfo};
+use crate::msg::{
+    AccountResponse, AllAccountsResponseItem, LienInfo, MaybeAccountResponse, StakingInitInfo,
+};
 use cosmwasm_std::StdError::GenericErr;
 use cosmwasm_std::{coin, coins, to_binary, Addr, Binary, Decimal, Empty, Uint128};
 use cw_multi_test::App as MtApp;
@@ -78,7 +80,6 @@ fn bonding() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::zero(),
             free: Uint128::zero(),
@@ -97,7 +98,6 @@ fn bonding() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(100),
             free: Uint128::new(100),
@@ -126,7 +126,6 @@ fn bonding() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(250),
             free: Uint128::new(250),
@@ -152,7 +151,6 @@ fn bonding() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(50),
             free: Uint128::new(50),
@@ -176,7 +174,6 @@ fn bonding() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(30),
             free: Uint128::new(30),
@@ -247,7 +244,6 @@ fn stake_local() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -280,7 +276,6 @@ fn stake_local() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -317,7 +312,6 @@ fn stake_local() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(50),
@@ -374,7 +368,6 @@ fn stake_local() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(100),
@@ -414,7 +407,6 @@ fn stake_local() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -514,7 +506,6 @@ fn stake_cross() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -560,7 +551,6 @@ fn stake_cross() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -607,7 +597,6 @@ fn stake_cross() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(50),
@@ -669,7 +658,6 @@ fn stake_cross() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(100),
@@ -711,7 +699,6 @@ fn stake_cross() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -807,7 +794,6 @@ fn stake_cross_txs() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -824,7 +810,6 @@ fn stake_cross_txs() {
     assert_eq!(
         vault.account(user2.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user2.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(500),
             free: Uint128::new(500),
@@ -936,15 +921,20 @@ fn stake_cross_txs() {
     assert_eq!(
         accounts.accounts,
         vec![
-            MaybeAccountResponse::Locked {
+            AllAccountsResponseItem {
                 user: user.to_string(),
+                account: MaybeAccountResponse::Locked {
+                    user: user.to_string()
+                }
             },
-            MaybeAccountResponse::Account(AccountResponse {
+            AllAccountsResponseItem {
                 user: user2.to_string(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(500),
-                free: Uint128::new(400),
-            }),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(500),
+                    free: Uint128::new(400),
+                }),
+            },
         ]
     );
 
@@ -953,7 +943,6 @@ fn stake_cross_txs() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user2.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(500),
             free: Uint128::new(400),
@@ -981,7 +970,6 @@ fn stake_cross_txs() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -1053,7 +1041,6 @@ fn stake_cross_rollback_tx() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -1094,7 +1081,6 @@ fn stake_cross_rollback_tx() {
     assert_eq!(
         acc,
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -1214,7 +1200,6 @@ fn multiple_stakes() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(1000),
             free: Uint128::new(700),
@@ -1276,7 +1261,6 @@ fn multiple_stakes() {
     assert_eq!(
         vault.account(user.to_owned()).unwrap().unwrap(),
         AccountResponse {
-            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(1000),
             free: Uint128::new(430),
@@ -1386,23 +1370,27 @@ fn all_users_fetching() {
     let accounts = vault.all_accounts(false, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [MaybeAccountResponse::Account(AccountResponse {
-            user: users[0].to_owned(),
-            denom: OSMO.to_owned(),
-            bonded: Uint128::new(100),
-            free: Uint128::new(100),
-        })]
+        [AllAccountsResponseItem {
+            user: users[0].to_string(),
+            account: MaybeAccountResponse::Account(AccountResponse {
+                denom: OSMO.to_owned(),
+                bonded: Uint128::new(100),
+                free: Uint128::new(100),
+            })
+        }]
     );
 
     let accounts = vault.all_accounts(true, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [MaybeAccountResponse::Account(AccountResponse {
-            user: users[0].to_owned(),
-            denom: OSMO.to_owned(),
-            bonded: Uint128::new(100),
-            free: Uint128::new(100),
-        })]
+        [AllAccountsResponseItem {
+            user: users[0].to_string(),
+            account: MaybeAccountResponse::Account(AccountResponse {
+                denom: OSMO.to_owned(),
+                bonded: Uint128::new(100),
+                free: Uint128::new(100),
+            })
+        }]
     );
 
     // Second user bonds - we want to see him
@@ -1417,18 +1405,22 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[0].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(100),
-                free: Uint128::new(100),
-            }),
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[1].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(200),
-                free: Uint128::new(200),
-            })
+            AllAccountsResponseItem {
+                user: users[0].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(100),
+                    free: Uint128::new(100),
+                })
+            },
+            AllAccountsResponseItem {
+                user: users[1].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(200),
+                    free: Uint128::new(200),
+                })
+            }
         ]
     );
 
@@ -1436,18 +1428,22 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[0].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(100),
-                free: Uint128::new(100),
-            }),
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[1].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(200),
-                free: Uint128::new(200),
-            })
+            AllAccountsResponseItem {
+                user: users[0].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(100),
+                    free: Uint128::new(100),
+                })
+            },
+            AllAccountsResponseItem {
+                user: users[1].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(200),
+                    free: Uint128::new(200),
+                })
+            }
         ]
     );
 
@@ -1459,18 +1455,22 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[0].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(50),
-                free: Uint128::new(50),
-            }),
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[1].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(200),
-                free: Uint128::new(200),
-            })
+            AllAccountsResponseItem {
+                user: users[0].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(50),
+                    free: Uint128::new(50),
+                })
+            },
+            AllAccountsResponseItem {
+                user: users[1].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(200),
+                    free: Uint128::new(200),
+                })
+            }
         ]
     );
 
@@ -1478,51 +1478,61 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[0].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(50),
-                free: Uint128::new(50),
-            }),
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[1].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(200),
-                free: Uint128::new(200),
-            })
+            AllAccountsResponseItem {
+                user: users[0].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(50),
+                    free: Uint128::new(50),
+                })
+            },
+            AllAccountsResponseItem {
+                user: users[1].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(200),
+                    free: Uint128::new(200),
+                })
+            }
         ]
     );
 
-    // Unbondning all the collateral hids the user when the collateral flag is set
+    // Unbonding all the collateral hides the user when the collateral flag is set
     vault.unbond(coin(200, OSMO)).call(users[1]).unwrap();
 
     let accounts = vault.all_accounts(false, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
         [
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[0].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(50),
-                free: Uint128::new(50),
-            }),
-            MaybeAccountResponse::Account(AccountResponse {
-                user: users[1].to_owned(),
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(0),
-                free: Uint128::new(0),
-            })
+            AllAccountsResponseItem {
+                user: users[0].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(50),
+                    free: Uint128::new(50),
+                })
+            },
+            AllAccountsResponseItem {
+                user: users[1].to_string(),
+                account: MaybeAccountResponse::Account(AccountResponse {
+                    denom: OSMO.to_owned(),
+                    bonded: Uint128::new(0),
+                    free: Uint128::new(0),
+                })
+            }
         ]
     );
 
     let accounts = vault.all_accounts(true, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [MaybeAccountResponse::Account(AccountResponse {
-            user: users[0].to_owned(),
-            denom: OSMO.to_owned(),
-            bonded: Uint128::new(50),
-            free: Uint128::new(50),
-        }),]
+        [AllAccountsResponseItem {
+            user: users[0].to_string(),
+            account: MaybeAccountResponse::Account(AccountResponse {
+                denom: OSMO.to_owned(),
+                bonded: Uint128::new(50),
+                free: Uint128::new(50),
+            })
+        },]
     );
 }

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -5,9 +5,7 @@ use crate::contract;
 use crate::contract::multitest_utils::VaultContractProxy;
 use crate::contract::test_utils::VaultApi;
 use crate::error::ContractError;
-use crate::msg::{
-    AccountResponse, AllAccountsResponseItem, LienInfo, StakingInitInfo, UnlockedAccountResponse,
-};
+use crate::msg::{AccountResponse, LienInfo, MaybeAccountResponse, StakingInitInfo};
 use cosmwasm_std::StdError::GenericErr;
 use cosmwasm_std::{coin, coins, to_binary, Addr, Binary, Decimal, Empty, Uint128};
 use cw_multi_test::App as MtApp;
@@ -78,8 +76,9 @@ fn bonding() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::zero(),
             free: Uint128::zero(),
@@ -96,8 +95,9 @@ fn bonding() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(100),
             free: Uint128::new(100),
@@ -124,8 +124,9 @@ fn bonding() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(250),
             free: Uint128::new(250),
@@ -149,8 +150,9 @@ fn bonding() {
 
     vault.unbond(coin(200, OSMO)).call(user).unwrap();
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(50),
             free: Uint128::new(50),
@@ -172,8 +174,9 @@ fn bonding() {
 
     vault.unbond(coin(20, OSMO)).call(user).unwrap();
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(30),
             free: Uint128::new(30),
@@ -242,8 +245,9 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -274,8 +278,9 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -310,8 +315,9 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(50),
@@ -366,8 +372,9 @@ fn stake_local() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(100),
@@ -405,8 +412,9 @@ fn stake_local() {
         .call(owner)
         .unwrap();
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -504,8 +512,9 @@ fn stake_cross() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -547,10 +556,11 @@ fn stake_cross() {
         .call(cross_staking.contract_addr.as_str())
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -593,10 +603,11 @@ fn stake_cross() {
         .call(cross_staking.contract_addr.as_str())
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(50),
@@ -654,10 +665,11 @@ fn stake_cross() {
         .call(owner)
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(100),
@@ -695,10 +707,11 @@ fn stake_cross() {
         .call(owner)
         .unwrap();
 
-    let acc = vault.account(user.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -792,8 +805,9 @@ fn stake_cross_txs() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -808,8 +822,9 @@ fn stake_cross_txs() {
         .call(user2)
         .unwrap();
     assert_eq!(
-        vault.account(user2.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user2.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user2.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(500),
             free: Uint128::new(500),
@@ -896,7 +911,9 @@ fn stake_cross_txs() {
     // Cannot query account while pending
     assert_eq!(
         vault.account(user.to_owned()).unwrap(),
-        AccountResponse::Locked {}
+        MaybeAccountResponse::Locked {
+            user: user.to_owned()
+        }
     ); // write locked
        // Cannot query claims while pending
        // TODO: locked enum not error
@@ -914,23 +931,29 @@ fn stake_cross_txs() {
             .unwrap(),
         coin(800, OSMO)
     );
-    // Can query all accounts, but locked ones are not returned
+    // Can query all accounts, and locked are reported
     let accounts = vault.all_accounts(false, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [AllAccountsResponseItem {
-            account: user2.to_string(),
-            denom: OSMO.to_owned(),
-            bonded: Uint128::new(500),
-            free: Uint128::new(400),
-        }]
+        vec![
+            MaybeAccountResponse::Locked {
+                user: user.to_string(),
+            },
+            MaybeAccountResponse::Account(AccountResponse {
+                user: user2.to_string(),
+                denom: OSMO.to_owned(),
+                bonded: Uint128::new(500),
+                free: Uint128::new(400),
+            }),
+        ]
     );
 
     // Can query the other account
-    let acc = vault.account(user2.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user2.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user2.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(500),
             free: Uint128::new(400),
@@ -954,10 +977,11 @@ fn stake_cross_txs() {
         .unwrap();
 
     // Can query account now
-    let acc = vault.account(user.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(200),
@@ -1027,8 +1051,9 @@ fn stake_cross_rollback_tx() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -1065,10 +1090,11 @@ fn stake_cross_rollback_tx() {
         .is_empty());
 
     // Funds are restored
-    let acc = vault.account(user.to_owned()).unwrap().unlocked();
+    let acc = vault.account(user.to_owned()).unwrap().unwrap();
     assert_eq!(
         acc,
-        UnlockedAccountResponse {
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: Uint128::new(300),
@@ -1186,8 +1212,9 @@ fn multiple_stakes() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(1000),
             free: Uint128::new(700),
@@ -1247,8 +1274,9 @@ fn multiple_stakes() {
         .unwrap();
 
     assert_eq!(
-        vault.account(user.to_owned()).unwrap().unlocked(),
-        UnlockedAccountResponse {
+        vault.account(user.to_owned()).unwrap().unwrap(),
+        AccountResponse {
+            user: user.to_string(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(1000),
             free: Uint128::new(430),
@@ -1358,23 +1386,23 @@ fn all_users_fetching() {
     let accounts = vault.all_accounts(false, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [AllAccountsResponseItem {
-            account: users[0].to_owned(),
+        [MaybeAccountResponse::Account(AccountResponse {
+            user: users[0].to_owned(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(100),
             free: Uint128::new(100),
-        }]
+        })]
     );
 
     let accounts = vault.all_accounts(true, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [AllAccountsResponseItem {
-            account: users[0].to_owned(),
+        [MaybeAccountResponse::Account(AccountResponse {
+            user: users[0].to_owned(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(100),
             free: Uint128::new(100),
-        }]
+        })]
     );
 
     // Second user bonds - we want to see him
@@ -1389,18 +1417,18 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            AllAccountsResponseItem {
-                account: users[0].to_owned(),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[0].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(100),
                 free: Uint128::new(100),
-            },
-            AllAccountsResponseItem {
-                account: users[1].to_owned(),
+            }),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[1].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(200),
                 free: Uint128::new(200),
-            }
+            })
         ]
     );
 
@@ -1408,18 +1436,18 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            AllAccountsResponseItem {
-                account: users[0].to_owned(),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[0].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(100),
                 free: Uint128::new(100),
-            },
-            AllAccountsResponseItem {
-                account: users[1].to_owned(),
+            }),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[1].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(200),
                 free: Uint128::new(200),
-            }
+            })
         ]
     );
 
@@ -1431,18 +1459,18 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            AllAccountsResponseItem {
-                account: users[0].to_owned(),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[0].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(50),
                 free: Uint128::new(50),
-            },
-            AllAccountsResponseItem {
-                account: users[1].to_owned(),
+            }),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[1].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(200),
                 free: Uint128::new(200),
-            }
+            })
         ]
     );
 
@@ -1450,18 +1478,18 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            AllAccountsResponseItem {
-                account: users[0].to_owned(),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[0].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(50),
                 free: Uint128::new(50),
-            },
-            AllAccountsResponseItem {
-                account: users[1].to_owned(),
+            }),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[1].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(200),
                 free: Uint128::new(200),
-            }
+            })
         ]
     );
 
@@ -1472,29 +1500,29 @@ fn all_users_fetching() {
     assert_eq!(
         accounts.accounts,
         [
-            AllAccountsResponseItem {
-                account: users[0].to_owned(),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[0].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(50),
                 free: Uint128::new(50),
-            },
-            AllAccountsResponseItem {
-                account: users[1].to_owned(),
+            }),
+            MaybeAccountResponse::Account(AccountResponse {
+                user: users[1].to_owned(),
                 denom: OSMO.to_owned(),
                 bonded: Uint128::new(0),
                 free: Uint128::new(0),
-            }
+            })
         ]
     );
 
     let accounts = vault.all_accounts(true, None, None).unwrap();
     assert_eq!(
         accounts.accounts,
-        [AllAccountsResponseItem {
-            account: users[0].to_owned(),
+        [MaybeAccountResponse::Account(AccountResponse {
+            user: users[0].to_owned(),
             denom: OSMO.to_owned(),
             bonded: Uint128::new(50),
             free: Uint128::new(50),
-        },]
+        }),]
     );
 }

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -896,9 +896,7 @@ fn stake_cross_txs() {
     // Cannot query account while pending
     assert_eq!(
         vault.account(user.to_owned()).unwrap(),
-        MaybeAccountResponse::Locked {
-            user: user.to_owned()
-        }
+        MaybeAccountResponse::Locked {}
     ); // write locked
        // Cannot query claims while pending
        // TODO: locked enum not error
@@ -923,9 +921,7 @@ fn stake_cross_txs() {
         vec![
             AllAccountsResponseItem {
                 user: user.to_string(),
-                account: MaybeAccountResponse::Locked {
-                    user: user.to_string()
-                }
+                account: MaybeAccountResponse::Locked {}
             },
             AllAccountsResponseItem {
                 user: user2.to_string(),

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -925,11 +925,11 @@ fn stake_cross_txs() {
             },
             AllAccountsResponseItem {
                 user: user2.to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(500),
-                    free: Uint128::new(400),
-                }),
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(500),
+                    Uint128::new(400)
+                ),
             },
         ]
     );
@@ -1368,11 +1368,7 @@ fn all_users_fetching() {
         accounts.accounts,
         [AllAccountsResponseItem {
             user: users[0].to_string(),
-            account: MaybeAccountResponse::Account(AccountResponse {
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(100),
-                free: Uint128::new(100),
-            })
+            account: MaybeAccountResponse::new_unlocked(OSMO, Uint128::new(100), Uint128::new(100)),
         }]
     );
 
@@ -1381,11 +1377,7 @@ fn all_users_fetching() {
         accounts.accounts,
         [AllAccountsResponseItem {
             user: users[0].to_string(),
-            account: MaybeAccountResponse::Account(AccountResponse {
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(100),
-                free: Uint128::new(100),
-            })
+            account: MaybeAccountResponse::new_unlocked(OSMO, Uint128::new(100), Uint128::new(100),)
         }]
     );
 
@@ -1403,19 +1395,19 @@ fn all_users_fetching() {
         [
             AllAccountsResponseItem {
                 user: users[0].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(100),
-                    free: Uint128::new(100),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(100),
+                    Uint128::new(100),
+                )
             },
             AllAccountsResponseItem {
                 user: users[1].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(200),
-                    free: Uint128::new(200),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(200),
+                    Uint128::new(200),
+                )
             }
         ]
     );
@@ -1426,19 +1418,19 @@ fn all_users_fetching() {
         [
             AllAccountsResponseItem {
                 user: users[0].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(100),
-                    free: Uint128::new(100),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(100),
+                    Uint128::new(100),
+                )
             },
             AllAccountsResponseItem {
                 user: users[1].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(200),
-                    free: Uint128::new(200),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(200),
+                    Uint128::new(200),
+                )
             }
         ]
     );
@@ -1453,19 +1445,19 @@ fn all_users_fetching() {
         [
             AllAccountsResponseItem {
                 user: users[0].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(50),
-                    free: Uint128::new(50),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(50),
+                    Uint128::new(50),
+                )
             },
             AllAccountsResponseItem {
                 user: users[1].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(200),
-                    free: Uint128::new(200),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(200),
+                    Uint128::new(200),
+                )
             }
         ]
     );
@@ -1476,19 +1468,19 @@ fn all_users_fetching() {
         [
             AllAccountsResponseItem {
                 user: users[0].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(50),
-                    free: Uint128::new(50),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(50),
+                    Uint128::new(50),
+                )
             },
             AllAccountsResponseItem {
                 user: users[1].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(200),
-                    free: Uint128::new(200),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(200),
+                    Uint128::new(200),
+                )
             }
         ]
     );
@@ -1502,19 +1494,15 @@ fn all_users_fetching() {
         [
             AllAccountsResponseItem {
                 user: users[0].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(50),
-                    free: Uint128::new(50),
-                })
+                account: MaybeAccountResponse::new_unlocked(
+                    OSMO,
+                    Uint128::new(50),
+                    Uint128::new(50),
+                )
             },
             AllAccountsResponseItem {
                 user: users[1].to_string(),
-                account: MaybeAccountResponse::Account(AccountResponse {
-                    denom: OSMO.to_owned(),
-                    bonded: Uint128::new(0),
-                    free: Uint128::new(0),
-                })
+                account: MaybeAccountResponse::new_unlocked(OSMO, Uint128::new(0), Uint128::new(0),)
             }
         ]
     );
@@ -1524,11 +1512,7 @@ fn all_users_fetching() {
         accounts.accounts,
         [AllAccountsResponseItem {
             user: users[0].to_string(),
-            account: MaybeAccountResponse::Account(AccountResponse {
-                denom: OSMO.to_owned(),
-                bonded: Uint128::new(50),
-                free: Uint128::new(50),
-            })
+            account: MaybeAccountResponse::new_unlocked(OSMO, Uint128::new(50), Uint128::new(50),)
         },]
     );
 }


### PR DESCRIPTION
If we expect query errors when the account is locked for in flight ibc transactions, we need to make it easy for the client to find this info. Trying to match error strings is not ideal. Let's return an enum for this state.

This is just one query. The vault claims, as well as the external-staking stake queries need a similar update, but I started the PR to show the idea.  @maurolacy  I would appreciate if you could finish this up.