### PR TITLE
Send Staking Rewards to provider stakers 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
 # 0.3.0-beta
 
-* IBC specification is added to the documents.
-* IBC types and logic added to `mesh-api::ibc`
-* `converter` and `external-staking` support ibc
-    * Handshake and channel creation
-    * Validator sync protocol (Consumer -> Provider)
-    * WIP: Staking protocol (Provider -> Consumer)
-    * TODO: Reward protocol (Consumer -> Provider)
+- IBC specification is added to the documents.
+- IBC types and logic added to `mesh-api::ibc`
+- `converter` and `external-staking` support ibc
+  - Handshake and channel creation
+  - Validator sync protocol (Consumer -> Provider)
+  - WIP: Staking protocol (Provider -> Consumer)
+  - TODO: Reward protocol (Consumer -> Provider)

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -1,10 +1,11 @@
 use cosmwasm_std::{
-    ensure_eq, to_binary, Addr, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, Reply, Response,
-    SubMsg, SubMsgResponse, WasmMsg, BankMsg,
+    ensure_eq, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, IbcMsg,
+    Reply, Response, SubMsg, SubMsgResponse, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
-use cw_utils::{nonpayable, parse_instantiate_response_data};
+use cw_utils::{must_pay, nonpayable, parse_instantiate_response_data};
+use mesh_apis::ibc::ConsumerPacket;
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx, ReplyCtx};
 use sylvia::{contract, schemars};
 
@@ -13,6 +14,7 @@ use mesh_apis::price_feed_api;
 use mesh_apis::virtual_staking_api;
 
 use crate::error::ContractError;
+use crate::ibc::{packet_timeout, IBC_CHANNEL};
 use crate::msg::ConfigResponse;
 use crate::state::Config;
 
@@ -265,11 +267,28 @@ impl ConverterApi for ConverterContract<'_> {
     type Error = ContractError;
 
     /// Rewards tokens (in native staking denom) are sent alongside the message, and should be distributed to all
-    /// stakers who staked on this validator.
+    /// stakers who staked on this validator. This is tracked on the provider, so we send an IBC packet there.
     #[msg(exec)]
     fn distribute_reward(&self, ctx: ExecCtx, validator: String) -> Result<Response, Self::Error> {
-        let _ = (ctx, validator);
-        todo!();
+        let config = self.config.load(ctx.deps.storage)?;
+        let denom = config.local_denom;
+        let amount = must_pay(&ctx.info, &denom)?;
+        let rewards = Coin { denom, amount };
+
+        let event = Event::new("distribute_reward")
+            .add_attribute("validator", &validator)
+            .add_attribute("amount", amount.to_string());
+
+        // Create a packet for the provider, informing of distribution
+        let packet = ConsumerPacket::Distribute { validator, rewards };
+        let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
+        let msg = IbcMsg::SendPacket {
+            channel_id: channel.endpoint.channel_id,
+            data: to_binary(&packet)?,
+            timeout: packet_timeout(&ctx.env),
+        };
+
+        Ok(Response::new().add_message(msg).add_event(event))
     }
 
     /// This is a batch for of distribute_reward, including the payment for multiple validators.
@@ -280,10 +299,21 @@ impl ConverterApi for ConverterContract<'_> {
     #[msg(exec)]
     fn distribute_rewards(
         &self,
-        ctx: ExecCtx,
+        mut ctx: ExecCtx,
         payments: Vec<RewardInfo>,
     ) -> Result<Response, Self::Error> {
-        let _ = (ctx, payments);
-        todo!();
+        // TODO: Optimize this, when we actually get such calls
+        let mut resp = Response::new();
+        for RewardInfo { validator, reward } in payments {
+            let mut sub_ctx = ctx.branch();
+            sub_ctx.info.funds[0].amount = reward;
+            let r = self.distribute_reward(sub_ctx, validator)?;
+            // put all values on the parent one
+            resp = resp
+                .add_submessages(r.messages)
+                .add_attributes(r.attributes)
+                .add_events(r.events);
+        }
+        Ok(resp)
     }
 }

--- a/contracts/consumer/converter/src/error.rs
+++ b/contracts/consumer/converter/src/error.rs
@@ -31,4 +31,10 @@ pub enum ContractError {
 
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
+
+    #[error("Invalid discount, must be between 0.0 and 1.0")]
+    InvalidDiscount,
+
+    #[error("Invalid denom: {0}")]
+    InvalidDenom(String),
 }

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -185,9 +185,7 @@ pub fn ibc_packet_receive(
                 .add_attributes(response.attributes)
         }
         ProviderPacket::TransferRewards {
-            rewards,
-            recipient,
-            staker: _,
+            rewards, recipient, ..
         } => {
             let msg = contract.transfer_rewards(deps.as_ref(), recipient, rewards)?;
             let ack = ack_success(&TransferRewardsAck {})?;

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -11,7 +11,7 @@ use cw_storage_plus::Item;
 
 use mesh_apis::ibc::{
     ack_success, validate_channel_order, AckWrapper, AddValidator, ConsumerPacket, ProtocolVersion,
-    ProviderPacket, StakeAck, UnstakeAck, PROTOCOL_NAME,
+    ProviderPacket, StakeAck, TransferRewardsAck, UnstakeAck, PROTOCOL_NAME,
 };
 
 use crate::{contract::ConverterContract, error::ContractError};
@@ -174,6 +174,15 @@ pub fn ibc_packet_receive(
                 .add_submessages(response.messages)
                 .add_events(response.events)
                 .add_attributes(response.attributes)
+        }
+        ProviderPacket::TransferRewards {
+            rewards,
+            recipient,
+            staker: _,
+        } => {
+            let msg = contract.transfer_rewards(deps.as_ref(), recipient, rewards)?;
+            let ack = ack_success(&TransferRewardsAck {})?;
+            IbcReceiveResponse::new().set_ack(ack).add_message(msg)
         }
     };
     Ok(res)

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -25,12 +25,21 @@ const MIN_IBC_PROTOCOL_VERSION: &str = "1.0.0";
 pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
 
 // Let those validator syncs take a day...
-const DEFAULT_TIMEOUT: u64 = 24 * 60 * 60;
+const DEFAULT_VALIDATOR_TIMEOUT: u64 = 24 * 60 * 60;
+// But reward messages should go faster or timeout
+const DEFAULT_REWARD_TIMEOUT: u64 = 60 * 60;
 
-pub fn packet_timeout(env: &Env) -> IbcTimeout {
+pub fn packet_timeout_validator(env: &Env) -> IbcTimeout {
     // No idea about their blocktime, but 24 hours ahead of our view of the clock
     // should be decently in the future.
-    let timeout = env.block.time.plus_seconds(DEFAULT_TIMEOUT);
+    let timeout = env.block.time.plus_seconds(DEFAULT_VALIDATOR_TIMEOUT);
+    IbcTimeout::with_timestamp(timeout)
+}
+
+pub fn packet_timeout_rewards(env: &Env) -> IbcTimeout {
+    // No idea about their blocktime, but 1 hour ahead of our view of the clock
+    // should be decently in the future.
+    let timeout = env.block.time.plus_seconds(DEFAULT_REWARD_TIMEOUT);
     IbcTimeout::with_timestamp(timeout)
 }
 
@@ -120,7 +129,7 @@ pub fn ibc_channel_connect(
     let msg = IbcMsg::SendPacket {
         channel_id: channel.endpoint.channel_id,
         data: to_binary(&packet)?,
-        timeout: packet_timeout(&env),
+        timeout: packet_timeout_validator(&env),
     };
 
     Ok(IbcBasicResponse::new().add_message(msg))
@@ -225,7 +234,7 @@ pub fn ibc_packet_timeout(
     let msg = IbcMsg::SendPacket {
         channel_id: msg.packet.src.channel_id,
         data: msg.packet.data,
-        timeout: packet_timeout(&env),
+        timeout: packet_timeout_validator(&env),
     };
     Ok(IbcBasicResponse::new().add_message(msg))
 }

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -22,12 +22,12 @@ const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "1.0.0";
 const MIN_IBC_PROTOCOL_VERSION: &str = "1.0.0";
 
 // IBC specific state
-const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
+pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
 
 // Let those validator syncs take a day...
 const DEFAULT_TIMEOUT: u64 = 24 * 60 * 60;
 
-fn packet_timeout(env: &Env) -> IbcTimeout {
+pub fn packet_timeout(env: &Env) -> IbcTimeout {
     // No idea about their blocktime, but 24 hours ahead of our view of the clock
     // should be decently in the future.
     let timeout = env.block.time.plus_seconds(DEFAULT_TIMEOUT);

--- a/contracts/consumer/virtual-staking/src/error.rs
+++ b/contracts/consumer/virtual-staking/src/error.rs
@@ -18,4 +18,7 @@ pub enum ContractError {
 
     #[error("Cannot unbond {1} tokens from validator {0}, not enough staked")]
     InsufficientBond(String, Uint128),
+
+    #[error("Invalid Reply ID. Don't recognize {0}")]
+    InvalidReplyId(u64),
 }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1,10 +1,10 @@
 use cosmwasm_std::{
-    coin, coins, ensure, ensure_eq, from_binary, Addr, BankMsg, Binary, Coin, Decimal, DepsMut,
-    Env, Order, Response, StdResult, Storage, Uint128, Uint256, WasmMsg,
+    coin, ensure, ensure_eq, from_binary, Addr, Binary, Coin, Decimal, DepsMut, Env, Event, Order,
+    Response, StdResult, Storage, Uint128, Uint256, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Bounder, Item, Map};
-use cw_utils::must_pay;
+use cw_utils::PaymentError;
 use mesh_apis::cross_staking_api::{self, CrossStakingApi};
 use mesh_apis::local_staking_api::MaxSlashResponse;
 use mesh_apis::vault_api::VaultApiHelper;
@@ -511,20 +511,46 @@ impl ExternalStakingContract<'_> {
         Ok(resp)
     }
 
-    /// Distributes reward among users staking via particular validator. Distribution is performend
-    /// proportionally to amount of tokens staken by user.
     #[msg(exec)]
     pub fn distribute_rewards(
         &self,
         ctx: ExecCtx,
         validator: String,
+        rewards: Coin,
     ) -> Result<Response, ContractError> {
-        let config = self.config.load(ctx.deps.storage)?;
-        let amount = must_pay(&ctx.info, &config.rewards_denom)?;
+        #[cfg(test)]
+        {
+            let event = self.do_distribute_rewards(ctx.deps, validator, rewards)?;
+            Ok(Response::new().add_event(event))
+        }
+        #[cfg(not(test))]
+        {
+            let _ = (ctx, validator, rewards);
+            panic!("This message is only available in test mode");
+        }
+    }
+
+    /// Distributes reward among users staking via particular validator. Distribution is performed
+    /// proportionally to amount of tokens staked by user.
+    /// This is called by IBC packets in real code, but also exposed in a test only message "distribute_rewards"
+    pub(crate) fn do_distribute_rewards(
+        &self,
+        deps: DepsMut,
+        validator: String,
+        rewards: Coin,
+    ) -> Result<Event, ContractError> {
+        // check we have the proper denom
+        let config = self.config.load(deps.storage)?;
+        ensure_eq!(
+            rewards.denom,
+            config.rewards_denom,
+            PaymentError::MissingDenom(rewards.denom)
+        );
+        let amount = rewards.amount;
 
         let mut distribution = self
             .distribution
-            .may_load(ctx.deps.storage, &validator)?
+            .may_load(deps.storage, &validator)?
             .unwrap_or_default();
 
         let total_stake = Uint256::from(distribution.total_stake);
@@ -536,15 +562,13 @@ impl ExternalStakingContract<'_> {
         distribution.points_per_stake += points_per_stake;
 
         self.distribution
-            .save(ctx.deps.storage, &validator, &distribution)?;
+            .save(deps.storage, &validator, &distribution)?;
 
-        let resp = Response::new()
-            .add_attribute("action", "distribute_rewards")
-            .add_attribute("sender", ctx.info.sender.into_string())
+        let event = Event::new("distribute_rewards")
             .add_attribute("validator", validator)
             .add_attribute("amount", amount.to_string());
 
-        Ok(resp)
+        Ok(event)
     }
 
     /// Withdraw rewards from staking via given validator
@@ -553,6 +577,8 @@ impl ExternalStakingContract<'_> {
         &self,
         ctx: ExecCtx,
         validator: String,
+        /// Address on the consumer side to receive the rewards
+        remote_recipient: String,
     ) -> Result<Response, ContractError> {
         let mut stake_lock = self
             .stakes
@@ -568,10 +594,12 @@ impl ExternalStakingContract<'_> {
 
         let amount = Self::calculate_reward(stake, &distribution)?;
 
+        #[allow(clippy::needless_borrow)]
         let mut resp = Response::new()
             .add_attribute("action", "withdraw_rewards")
             .add_attribute("owner", ctx.info.sender.to_string())
             .add_attribute("validator", &validator)
+            .add_attribute("recipient", &remote_recipient)
             .add_attribute("amount", amount.to_string());
 
         if !amount.is_zero() {
@@ -583,13 +611,34 @@ impl ExternalStakingContract<'_> {
                 &stake_lock,
             )?;
 
-            let config = self.config.load(ctx.deps.storage)?;
-            let send_msg = BankMsg::Send {
-                to_address: ctx.info.sender.into_string(),
-                amount: coins(amount.u128(), config.rewards_denom),
-            };
+            #[cfg(not(test))]
+            {
+                let config = self.config.load(ctx.deps.storage)?;
+                let rewards = coin(amount.u128(), config.rewards_denom);
+                // Send IBC Packet over the wire
+                let packet = ProviderPacket::TransferRewards {
+                    rewards,
+                    recipient: remote_recipient,
+                    staker: ctx.info.sender.into(),
+                };
 
-            resp = resp.add_message(send_msg);
+                // TODO: error on None (use load) once we have better test setup
+                let channel_id = IBC_CHANNEL
+                    .may_load(ctx.deps.storage)?
+                    .map(|ch| ch.endpoint.channel_id)
+                    .unwrap_or_else(|| "channel-69".to_string());
+                let send_msg = IbcMsg::SendPacket {
+                    channel_id,
+                    data: to_binary(&packet)?,
+                    timeout: packet_timeout(&ctx.env),
+                };
+                resp = resp.add_message(send_msg);
+            }
+            #[cfg(test)]
+            {
+                // just to avoid clippy complaint about mut above
+                resp = resp.add_attribute("test", "test");
+            }
         }
 
         Ok(resp)

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -512,7 +512,7 @@ impl ExternalStakingContract<'_> {
     }
 
     #[msg(exec)]
-    pub fn distribute_rewards(
+    pub fn test_distribute_rewards(
         &self,
         ctx: ExecCtx,
         validator: String,
@@ -520,7 +520,7 @@ impl ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(test)]
         {
-            let event = self.do_distribute_rewards(ctx.deps, validator, rewards)?;
+            let event = self.distribute_rewards(ctx.deps, validator, rewards)?;
             Ok(Response::new().add_event(event))
         }
         #[cfg(not(test))]
@@ -532,8 +532,8 @@ impl ExternalStakingContract<'_> {
 
     /// Distributes reward among users staking via particular validator. Distribution is performed
     /// proportionally to amount of tokens staked by user.
-    /// This is called by IBC packets in real code, but also exposed in a test only message "distribute_rewards"
-    pub(crate) fn do_distribute_rewards(
+    /// This is called by IBC packets in real code, but also exposed in a test only message "test_distribute_rewards"
+    pub(crate) fn distribute_rewards(
         &self,
         deps: DepsMut,
         validator: String,

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -620,13 +620,14 @@ impl ExternalStakingContract<'_> {
                     rewards,
                     recipient: remote_recipient,
                     staker: ctx.info.sender.into(),
+                    validator,
                 };
 
                 // TODO: error on None (use load) once we have better test setup
                 let channel_id = IBC_CHANNEL
                     .may_load(ctx.deps.storage)?
                     .map(|ch| ch.endpoint.channel_id)
-                    .unwrap_or_else(|| "channel-69".to_string());
+                    .unwrap_or_else(|| "channel-72".to_string());
                 let send_msg = IbcMsg::SendPacket {
                     channel_id,
                     data: to_binary(&packet)?,
@@ -642,6 +643,22 @@ impl ExternalStakingContract<'_> {
         }
 
         Ok(resp)
+    }
+
+    pub(crate) fn unwithdraw_rewards(
+        &self,
+        deps: DepsMut,
+        sender: &Addr,
+        validator: &str,
+        amount: Uint128,
+    ) -> Result<(), ContractError> {
+        let mut stake_lock = self.stakes.load(deps.storage, (sender, validator))?;
+        let stake = stake_lock.write()?;
+        stake.withdrawn_funds += amount;
+        self.stakes
+            .save(deps.storage, (sender, validator), &stake_lock)?;
+
+        Ok(())
     }
 
     /// Queries for contract configuration

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -288,7 +288,6 @@ impl ExternalStakingContract<'_> {
         let tx_id = self.next_tx_id(ctx.deps.storage)?;
 
         // Save tx
-        #[allow(clippy::redundant_clone)]
         let new_tx = Tx::InFlightRemoteUnstaking {
             id: tx_id,
             amount: amount.amount,
@@ -297,29 +296,32 @@ impl ExternalStakingContract<'_> {
         };
         self.pending_txs.save(ctx.deps.storage, tx_id, &new_tx)?;
 
+        #[allow(unused_mut)]
         let mut resp = Response::new()
             .add_attribute("action", "unstake")
-            .add_attribute("amount", amount.amount.to_string());
+            .add_attribute("amount", amount.amount.to_string())
+            .add_attribute("owner", ctx.info.sender);
 
-        // add ibc packet if we are ibc enabled (skip in tests)
+        let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
+        let packet = ProviderPacket::Unstake {
+            validator,
+            unstake: amount,
+            tx_id,
+        };
+        let msg = IbcMsg::SendPacket {
+            channel_id: channel.endpoint.channel_id,
+            data: to_binary(&packet)?,
+            timeout: packet_timeout(&ctx.env),
+        };
+        // send packet if we are ibc enabled (skip in tests)
         #[cfg(not(test))]
         {
-            let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
-            let packet = ProviderPacket::Unstake {
-                validator,
-                unstake: amount,
-                tx_id,
-            };
-            let msg = IbcMsg::SendPacket {
-                channel_id: channel.endpoint.channel_id,
-                data: to_binary(&packet)?,
-                timeout: packet_timeout(&ctx.env),
-            };
             resp = resp.add_message(msg);
         }
-
-        // put this later so compiler doens't complain about mut in test mode
-        resp = resp.add_attribute("owner", ctx.info.sender);
+        #[cfg(test)]
+        {
+            let _ = msg;
+        }
 
         Ok(resp)
     }
@@ -981,7 +983,6 @@ pub mod cross_staking {
                 .save(ctx.deps.storage, (&owner, &msg.validator), &stake_lock)?;
 
             // Save tx
-            #[allow(clippy::redundant_clone)]
             let new_tx = Tx::InFlightRemoteStaking {
                 id: tx_id,
                 amount: amount.amount,
@@ -992,21 +993,25 @@ pub mod cross_staking {
 
             let mut resp = Response::new();
 
+            let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
+            let packet = ProviderPacket::Stake {
+                validator: msg.validator,
+                stake: amount.clone(),
+                tx_id,
+            };
+            let msg = IbcMsg::SendPacket {
+                channel_id: channel.endpoint.channel_id,
+                data: to_binary(&packet)?,
+                timeout: packet_timeout(&ctx.env),
+            };
             // add ibc packet if we are ibc enabled (skip in tests)
             #[cfg(not(test))]
             {
-                let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
-                let packet = ProviderPacket::Stake {
-                    validator: msg.validator,
-                    stake: amount.clone(),
-                    tx_id,
-                };
-                let msg = IbcMsg::SendPacket {
-                    channel_id: channel.endpoint.channel_id,
-                    data: to_binary(&packet)?,
-                    timeout: packet_timeout(&ctx.env),
-                };
                 resp = resp.add_message(msg);
+            }
+            #[cfg(test)]
+            {
+                let _ = msg;
             }
 
             resp = resp

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -526,7 +526,7 @@ impl ExternalStakingContract<'_> {
         #[cfg(not(test))]
         {
             let _ = (ctx, validator, rewards);
-            panic!("This message is only available in test mode");
+            Err(ContractError::Unauthorized)
         }
     }
 
@@ -594,6 +594,7 @@ impl ExternalStakingContract<'_> {
 
         let amount = Self::calculate_reward(stake, &distribution)?;
 
+        #[allow(unused_mut)]
         #[allow(clippy::needless_borrow)]
         let mut resp = Response::new()
             .add_attribute("action", "withdraw_rewards")
@@ -623,22 +624,13 @@ impl ExternalStakingContract<'_> {
                     validator,
                 };
 
-                // TODO: error on None (use load) once we have better test setup
-                let channel_id = IBC_CHANNEL
-                    .may_load(ctx.deps.storage)?
-                    .map(|ch| ch.endpoint.channel_id)
-                    .unwrap_or_else(|| "channel-72".to_string());
+                let channel_id = IBC_CHANNEL.load(ctx.deps.storage)?.endpoint.channel_id;
                 let send_msg = IbcMsg::SendPacket {
                     channel_id,
                     data: to_binary(&packet)?,
                     timeout: packet_timeout(&ctx.env),
                 };
                 resp = resp.add_message(send_msg);
-            }
-            #[cfg(test)]
-            {
-                // just to avoid clippy complaint about mut above
-                resp = resp.add_attribute("test", "test");
             }
         }
 

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -10,12 +10,8 @@ use mesh_apis::local_staking_api::MaxSlashResponse;
 use mesh_apis::vault_api::VaultApiHelper;
 use mesh_sync::Lockable;
 
-// IBC sending is disabled in tests...
-#[cfg(not(test))]
 use crate::ibc::{packet_timeout, IBC_CHANNEL};
-#[cfg(not(test))]
 use cosmwasm_std::{to_binary, IbcMsg};
-#[cfg(not(test))]
 use mesh_apis::ibc::ProviderPacket;
 
 use sylvia::contract;
@@ -102,6 +98,17 @@ impl ExternalStakingContract<'_> {
 
         remote_contact.validate()?;
         crate::ibc::AUTH_ENDPOINT.save(ctx.deps.storage, &remote_contact)?;
+
+        // test code sets a channel, so we can closer approximate ibc in test code
+        #[cfg(test)]
+        {
+            let channel = cosmwasm_std::testing::mock_ibc_channel(
+                "channel-172",
+                cosmwasm_std::IbcOrder::Unordered,
+                "mesh-security",
+            );
+            crate::ibc::IBC_CHANNEL.save(ctx.deps.storage, &channel)?;
+        }
 
         Ok(Response::new())
     }
@@ -585,7 +592,7 @@ impl ExternalStakingContract<'_> {
             .may_load(ctx.deps.storage, (&ctx.info.sender, &validator))?
             .unwrap_or_default();
 
-        let stake = stake_lock.write()?;
+        let stake = stake_lock.read()?;
 
         let distribution = self
             .distribution
@@ -594,8 +601,11 @@ impl ExternalStakingContract<'_> {
 
         let amount = Self::calculate_reward(stake, &distribution)?;
 
+        if amount.is_zero() {
+            return Err(ContractError::NoRewards);
+        }
+
         #[allow(unused_mut)]
-        #[allow(clippy::needless_borrow)]
         let mut resp = Response::new()
             .add_attribute("action", "withdraw_rewards")
             .add_attribute("owner", ctx.info.sender.to_string())
@@ -603,52 +613,149 @@ impl ExternalStakingContract<'_> {
             .add_attribute("recipient", &remote_recipient)
             .add_attribute("amount", amount.to_string());
 
-        if !amount.is_zero() {
-            stake.withdrawn_funds += amount;
+        // lock the stake. the withdrawn_funds will be updated on a commit,
+        // left unchanged on rollback
+        stake_lock.lock_write()?;
+        self.stakes.save(
+            ctx.deps.storage,
+            (&ctx.info.sender, &validator),
+            &stake_lock,
+        )?;
 
-            self.stakes.save(
-                ctx.deps.storage,
-                (&ctx.info.sender, &validator),
-                &stake_lock,
-            )?;
+        // prepare the pending tx
+        let tx_id = self.next_tx_id(ctx.deps.storage)?;
+        let new_tx = Tx::InFlightTransferFunds {
+            id: tx_id,
+            amount,
+            staker: ctx.info.sender,
+            validator,
+        };
+        self.pending_txs.save(ctx.deps.storage, tx_id, &new_tx)?;
 
-            #[cfg(not(test))]
-            {
-                let config = self.config.load(ctx.deps.storage)?;
-                let rewards = coin(amount.u128(), config.rewards_denom);
-                // Send IBC Packet over the wire
-                let packet = ProviderPacket::TransferRewards {
-                    rewards,
-                    recipient: remote_recipient,
-                    staker: ctx.info.sender.into(),
-                    validator,
-                };
+        // Crate the IBC packet
+        let config = self.config.load(ctx.deps.storage)?;
+        let rewards = coin(amount.u128(), config.rewards_denom);
+        let packet = ProviderPacket::TransferRewards {
+            rewards,
+            recipient: remote_recipient,
+            tx_id,
+        };
+        let channel_id = IBC_CHANNEL.load(ctx.deps.storage)?.endpoint.channel_id;
+        let send_msg = IbcMsg::SendPacket {
+            channel_id,
+            data: to_binary(&packet)?,
+            timeout: packet_timeout(&ctx.env),
+        };
 
-                let channel_id = IBC_CHANNEL.load(ctx.deps.storage)?.endpoint.channel_id;
-                let send_msg = IbcMsg::SendPacket {
-                    channel_id,
-                    data: to_binary(&packet)?,
-                    timeout: packet_timeout(&ctx.env),
-                };
-                resp = resp.add_message(send_msg);
-            }
+        // TODO: send in test code when we can handle it
+        #[cfg(not(test))]
+        {
+            resp = resp.add_message(send_msg);
+        }
+        #[cfg(test)]
+        {
+            let _ = send_msg;
         }
 
         Ok(resp)
     }
 
-    pub(crate) fn unwithdraw_rewards(
+    #[msg(exec)]
+    fn test_commit_withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        tx_id: u64,
+    ) -> Result<Response, ContractError> {
+        #[cfg(test)]
+        {
+            self.commit_withdraw_rewards(ctx.deps, tx_id)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(test))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    #[msg(exec)]
+    fn test_rollback_withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        tx_id: u64,
+    ) -> Result<Response, ContractError> {
+        #[cfg(test)]
+        {
+            self.rollback_withdraw_rewards(ctx.deps, tx_id)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(test))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    pub(crate) fn rollback_withdraw_rewards(
         &self,
         deps: DepsMut,
-        sender: &Addr,
-        validator: &str,
-        amount: Uint128,
+        tx_id: u64,
     ) -> Result<(), ContractError> {
-        let mut stake_lock = self.stakes.load(deps.storage, (sender, validator))?;
+        // Load tx
+        let tx = self.pending_txs.load(deps.storage, tx_id)?;
+        self.pending_txs.remove(deps.storage, tx_id);
+
+        // Verify tx is of the right type and get data
+        let (_amount, staker, validator) = match tx {
+            Tx::InFlightTransferFunds {
+                amount,
+                staker,
+                validator,
+                ..
+            } => (amount, staker, validator),
+            _ => {
+                return Err(ContractError::WrongTypeTx(tx_id, tx));
+            }
+        };
+
+        // release the write lock and leave state unchanged
+        let mut stake_lock = self.stakes.load(deps.storage, (&staker, &validator))?;
+        stake_lock.unlock_write()?;
+        self.stakes
+            .save(deps.storage, (&staker, &validator), &stake_lock)?;
+
+        Ok(())
+    }
+
+    pub(crate) fn commit_withdraw_rewards(
+        &self,
+        deps: DepsMut,
+        tx_id: u64,
+    ) -> Result<(), ContractError> {
+        // Load tx
+        let tx = self.pending_txs.load(deps.storage, tx_id)?;
+        self.pending_txs.remove(deps.storage, tx_id);
+
+        // Verify tx is of the right type and get data
+        let (amount, staker, validator) = match tx {
+            Tx::InFlightTransferFunds {
+                amount,
+                staker,
+                validator,
+                ..
+            } => (amount, staker, validator),
+            _ => {
+                return Err(ContractError::WrongTypeTx(tx_id, tx));
+            }
+        };
+
+        // release the write lock and update withdrawn_funds to hold this transfer
+        let mut stake_lock = self.stakes.load(deps.storage, (&staker, &validator))?;
+        stake_lock.unlock_write()?;
         let stake = stake_lock.write()?;
         stake.withdrawn_funds += amount;
         self.stakes
-            .save(deps.storage, (sender, validator), &stake_lock)?;
+            .save(deps.storage, (&staker, &validator), &stake_lock)?;
 
         Ok(())
     }

--- a/contracts/provider/external-staking/src/error.rs
+++ b/contracts/provider/external-staking/src/error.rs
@@ -47,4 +47,7 @@ pub enum ContractError {
 
     #[error("The tx {0} exists but is of the wrong type: {1}")]
     WrongTypeTx(u64, Tx),
+
+    #[error("No staking rewards to be withdrawn")]
+    NoRewards,
 }

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -197,6 +197,21 @@ pub fn ibc_packet_ack(
                 .add_attribute("error", e)
                 .add_attribute("tx_id", tx_id.to_string());
         }
+        (ProviderPacket::TransferRewards { .. }, AckWrapper::Result(_)) => {
+            // do nothing, funds already transferred
+        }
+        (
+            ProviderPacket::TransferRewards {
+                rewards, staker, ..
+            },
+            AckWrapper::Error(e),
+        ) => {
+            // TODO: rollback the transfer by reducing the withdrawn amount for this staker
+            let _ = (rewards, staker);
+            resp = resp
+                .add_attribute("error", e)
+                .add_attribute("packet", msg.original_packet.sequence.to_string());
+        }
     }
 
     // Question: do we need a special event with all this info on error?
@@ -231,6 +246,13 @@ pub fn ibc_packet_timeout(
         ProviderPacket::Unstake { tx_id, .. } => {
             contract.rollback_unstake(deps, tx_id)?;
             resp = resp.add_attribute("tx_id", tx_id.to_string());
+        }
+        ProviderPacket::TransferRewards {
+            rewards, staker, ..
+        } => {
+            // TODO: rollback the transfer by reducing the withdrawn amount for this staker
+            let _ = (rewards, staker);
+            resp = resp.add_attribute("packet", msg.packet.sequence.to_string());
         }
     };
     Ok(resp)

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -205,21 +205,12 @@ pub fn ibc_packet_ack(
                 .add_attribute("error", e)
                 .add_attribute("tx_id", tx_id.to_string());
         }
-        (ProviderPacket::TransferRewards { .. }, AckWrapper::Result(_)) => {
-            // do nothing, funds already transferred
+        (ProviderPacket::TransferRewards { tx_id, .. }, AckWrapper::Result(_)) => {
+            // Any events to add?
+            contract.commit_withdraw_rewards(deps, tx_id)?;
         }
-        (
-            ProviderPacket::TransferRewards {
-                rewards,
-                staker,
-                validator,
-                ..
-            },
-            AckWrapper::Error(e),
-        ) => {
-            let staker = deps.api.addr_validate(&staker)?;
-            contract.unwithdraw_rewards(deps, &staker, &validator, rewards.amount)?;
-            let _ = (rewards, staker);
+        (ProviderPacket::TransferRewards { tx_id, .. }, AckWrapper::Error(e)) => {
+            contract.rollback_withdraw_rewards(deps, tx_id)?;
             resp = resp
                 .add_attribute("error", e)
                 .add_attribute("packet", msg.original_packet.sequence.to_string());
@@ -259,18 +250,9 @@ pub fn ibc_packet_timeout(
             contract.rollback_unstake(deps, tx_id)?;
             resp = resp.add_attribute("tx_id", tx_id.to_string());
         }
-        ProviderPacket::TransferRewards {
-            rewards,
-            staker,
-            validator,
-            ..
-        } => {
-            // rollback the transfer by reducing the withdrawn amount for this staker
-            let staker = deps.api.addr_validate(&staker)?;
-            contract.unwithdraw_rewards(deps, &staker, &validator, rewards.amount)?;
-            let _ = (rewards, staker);
-            resp = resp.add_attribute("packet", msg.packet.sequence.to_string());
-            resp = resp.add_attribute("packet", msg.packet.sequence.to_string());
+        ProviderPacket::TransferRewards { tx_id, .. } => {
+            contract.rollback_withdraw_rewards(deps, tx_id)?;
+            resp = resp.add_attribute("tx_id", tx_id.to_string());
         }
     };
     Ok(resp)

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 use cw_storage_plus::Item;
 use mesh_apis::ibc::{
     ack_success, validate_channel_order, AckWrapper, AddValidator, AddValidatorsAck,
-    ConsumerPacket, ProtocolVersion, ProviderPacket, RemoveValidatorsAck,
+    ConsumerPacket, DistributeAck, ProtocolVersion, ProviderPacket, RemoveValidatorsAck,
 };
 
 use crate::{
@@ -128,7 +128,7 @@ pub fn ibc_packet_receive(
     // There is only one channel, so we don't need to switch.
     // We also don't care about packet sequence as this is fully commutative.
     let packet: ConsumerPacket = from_slice(&msg.packet.data)?;
-    let ack = match packet {
+    let resp = match packet {
         ConsumerPacket::AddValidators(to_add) => {
             for AddValidator {
                 valoper,
@@ -144,18 +144,26 @@ pub fn ibc_packet_receive(
                 };
                 VAL_CRDT.add_validator(deps.storage, &valoper, update)?;
             }
-            ack_success(&AddValidatorsAck {})?
+            let ack = ack_success(&AddValidatorsAck {})?;
+            IbcReceiveResponse::new().set_ack(ack)
         }
         ConsumerPacket::RemoveValidators(to_remove) => {
             for valoper in to_remove {
                 VAL_CRDT.remove_validator(deps.storage, &valoper)?;
             }
-            ack_success(&RemoveValidatorsAck {})?
+            let ack = ack_success(&RemoveValidatorsAck {})?;
+            IbcReceiveResponse::new().set_ack(ack)
+        }
+        ConsumerPacket::Distribute { validator, rewards } => {
+            let contract = ExternalStakingContract::new();
+            let evt = contract.do_distribute_rewards(deps, validator, rewards)?;
+            let ack = ack_success(&DistributeAck {})?;
+            IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }
     };
 
     // return empty success ack
-    Ok(IbcReceiveResponse::new().set_ack(ack))
+    Ok(resp)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -210,11 +210,15 @@ pub fn ibc_packet_ack(
         }
         (
             ProviderPacket::TransferRewards {
-                rewards, staker, ..
+                rewards,
+                staker,
+                validator,
+                ..
             },
             AckWrapper::Error(e),
         ) => {
-            // TODO: rollback the transfer by reducing the withdrawn amount for this staker
+            let staker = deps.api.addr_validate(&staker)?;
+            contract.unwithdraw_rewards(deps, &staker, &validator, rewards.amount)?;
             let _ = (rewards, staker);
             resp = resp
                 .add_attribute("error", e)
@@ -256,10 +260,16 @@ pub fn ibc_packet_timeout(
             resp = resp.add_attribute("tx_id", tx_id.to_string());
         }
         ProviderPacket::TransferRewards {
-            rewards, staker, ..
+            rewards,
+            staker,
+            validator,
+            ..
         } => {
-            // TODO: rollback the transfer by reducing the withdrawn amount for this staker
+            // rollback the transfer by reducing the withdrawn amount for this staker
+            let staker = deps.api.addr_validate(&staker)?;
+            contract.unwithdraw_rewards(deps, &staker, &validator, rewards.amount)?;
             let _ = (rewards, staker);
+            resp = resp.add_attribute("packet", msg.packet.sequence.to_string());
             resp = resp.add_attribute("packet", msg.packet.sequence.to_string());
         }
     };

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -156,7 +156,7 @@ pub fn ibc_packet_receive(
         }
         ConsumerPacket::Distribute { validator, rewards } => {
             let contract = ExternalStakingContract::new();
-            let evt = contract.do_distribute_rewards(deps, validator, rewards)?;
+            let evt = contract.distribute_rewards(deps, validator, rewards)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -704,14 +704,14 @@ fn distribution() {
     // 20 tokens for users[0]
     // 30 tokens for users[1]
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(50, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(50, STAR))
         .call(owner)
         .unwrap();
 
     // Only users[0] stakes on validators[1]
     // 30 tokens for users[1]
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(30, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(30, STAR))
         .call(owner)
         .unwrap();
 
@@ -741,13 +741,13 @@ fn distribution() {
     // 42 tokens for users[1]
     // 1 token is not distributed
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(71, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(71, STAR))
         .call(owner)
         .unwrap();
 
     // Distribution in invalid coin should fail
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(100, OSMO))
+        .test_distribute_rewards(validators[1].to_owned(), coin(100, OSMO))
         .call(owner)
         .unwrap_err();
 
@@ -844,7 +844,7 @@ fn distribution() {
     //
     // The additional 1 token is leftover after previous allocation
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(9, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(9, STAR))
         .call(owner)
         .unwrap();
 
@@ -864,7 +864,7 @@ fn distribution() {
     // 4 on users[0] (+ ~0.4)
     // 6 on users[1] (+ ~0.6)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(11, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
 
@@ -872,7 +872,7 @@ fn distribution() {
     //
     // 11 on users[0]
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(11, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
 
@@ -937,7 +937,7 @@ fn distribution() {
     // 10 on users[0] (~0.4 still not distributed)
     // 10 on users[1] (~0.6 still not distributed)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(20, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(20, STAR))
         .call(owner)
         .unwrap();
 
@@ -945,7 +945,7 @@ fn distribution() {
     // 10 on users[1]
     // 30 on users[2]
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(40, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(40, STAR))
         .call(owner)
         .unwrap();
 
@@ -976,7 +976,7 @@ fn distribution() {
     // 3 for users[1] (+ ~0.5 from this distribution + ~0.6 accumulated -> ~1.1 tokens, we give one
     //   back leaving ~0.1 accumulated)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(5, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(5, STAR))
         .call(owner)
         .unwrap();
 
@@ -1024,7 +1024,7 @@ fn distribution() {
     // 7 + 1 = 8 to users[0] (~0.9 accumulated + ~0.2 = ~1.1 leftover, 1.0 payed back, ~0.1 accumulated)
     // 4 to users[0] (~0.1 accumulated + ~0.8 -> leaving at ~0.9)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(12, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(12, STAR))
         .call(owner)
         .unwrap();
 
@@ -1113,12 +1113,12 @@ fn distribution() {
     // 2 tokens to users[0] via validators[1] (~0.5 leftover)
     // 7 tokens to users[1] via validators[1] (~0.5 lefover)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(10, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(10, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -599,6 +599,7 @@ fn unstaking() {
 fn distribution() {
     let owner = "owner";
     let users = ["user1", "user2"];
+    let remote = ["remote1", "remote2"];
 
     let app = MtApp::new(|router, _api, storage| {
         router
@@ -703,16 +704,14 @@ fn distribution() {
     // 20 tokens for users[0]
     // 30 tokens for users[1]
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(50, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(50, STAR))
         .call(owner)
         .unwrap();
 
     // Only users[0] stakes on validators[1]
     // 30 tokens for users[1]
     contract
-        .distribute_rewards(validators[1].to_owned())
-        .with_funds(&coins(30, STAR))
+        .distribute_rewards(validators[1].to_owned(), coin(30, STAR))
         .call(owner)
         .unwrap();
 
@@ -737,29 +736,18 @@ fn distribution() {
         .unwrap();
     assert_eq!(rewards.amount.amount.u128(), 0);
 
-    // Distributed funds should be on the staking contract
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_all_balances(contract.contract_addr.clone())
-            .unwrap(),
-        coins(80, STAR)
-    );
-
     // Some more distribution, this time not divisible by total staken tokens
     // 28 tokens for users[0]
     // 42 tokens for users[1]
     // 1 token is not distributed
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(71, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(71, STAR))
         .call(owner)
         .unwrap();
 
     // Distribution in invalid coin should fail
     contract
-        .distribute_rewards(validators[1].to_owned())
-        .with_funds(&coins(100, OSMO))
+        .distribute_rewards(validators[1].to_owned(), coin(100, OSMO))
         .call(owner)
         .unwrap_err();
 
@@ -786,22 +774,22 @@ fn distribution() {
 
     // Withdraw rewards
     contract
-        .withdraw_rewards(validators[0].to_owned())
+        .withdraw_rewards(validators[0].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[1].to_owned())
+        .withdraw_rewards(validators[1].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[0].to_owned())
+        .withdraw_rewards(validators[0].to_owned(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[1].to_owned())
+        .withdraw_rewards(validators[1].to_owned(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
 
@@ -826,7 +814,9 @@ fn distribution() {
         .unwrap();
     assert_eq!(rewards.amount.amount.u128(), 0);
 
-    // Rewads should be on users accounts
+    // TODO: change this to somehow assert ibc packets
+    /*
+    // Rewards should be on users accounts
     assert_eq!(
         app.app()
             .wrap()
@@ -846,6 +836,7 @@ fn distribution() {
             .u128(),
         72
     );
+    */
 
     // Anothed distribution - making it equal
     // 4 on users[0]
@@ -853,8 +844,7 @@ fn distribution() {
     //
     // The additional 1 token is leftover after previous allocation
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(9, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(9, STAR))
         .call(owner)
         .unwrap();
 
@@ -874,8 +864,7 @@ fn distribution() {
     // 4 on users[0] (+ ~0.4)
     // 6 on users[1] (+ ~0.6)
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(11, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
 
@@ -883,8 +872,7 @@ fn distribution() {
     //
     // 11 on users[0]
     contract
-        .distribute_rewards(validators[1].to_owned())
-        .with_funds(&coins(11, STAR))
+        .distribute_rewards(validators[1].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
 
@@ -949,8 +937,7 @@ fn distribution() {
     // 10 on users[0] (~0.4 still not distributed)
     // 10 on users[1] (~0.6 still not distributed)
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(20, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(20, STAR))
         .call(owner)
         .unwrap();
 
@@ -958,8 +945,7 @@ fn distribution() {
     // 10 on users[1]
     // 30 on users[2]
     contract
-        .distribute_rewards(validators[1].to_owned())
-        .with_funds(&coins(40, STAR))
+        .distribute_rewards(validators[1].to_owned(), coin(40, STAR))
         .call(owner)
         .unwrap();
 
@@ -990,8 +976,7 @@ fn distribution() {
     // 3 for users[1] (+ ~0.5 from this distribution + ~0.6 accumulated -> ~1.1 tokens, we give one
     //   back leaving ~0.1 accumulated)
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(5, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(5, STAR))
         .call(owner)
         .unwrap();
 
@@ -1039,8 +1024,7 @@ fn distribution() {
     // 7 + 1 = 8 to users[0] (~0.9 accumulated + ~0.2 = ~1.1 leftover, 1.0 payed back, ~0.1 accumulated)
     // 4 to users[0] (~0.1 accumulated + ~0.8 -> leaving at ~0.9)
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(12, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(12, STAR))
         .call(owner)
         .unwrap();
 
@@ -1056,12 +1040,12 @@ fn distribution() {
 
     // Withdraw only by users[0]
     contract
-        .withdraw_rewards(validators[0].to_owned())
+        .withdraw_rewards(validators[0].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[1].to_owned())
+        .withdraw_rewards(validators[1].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
 
@@ -1086,9 +1070,11 @@ fn distribution() {
         .unwrap();
     assert_eq!(rewards.amount.amount.u128(), 30);
 
+    // TODO: update for IBC
     // Balances was previously:
     // 78 on users[0] - now witdrawing 28 from validators[0] and 21 from validators[1]
     // 72 on users[1] - should be the same
+    /*
     assert_eq!(
         app.app()
             .wrap()
@@ -1119,6 +1105,7 @@ fn distribution() {
             .u128(),
         60
     );
+    */
 
     // Final distribution - 10 tokens to both validators
     // 6 tokens to users[0] via validators[0] (leftover as it was)
@@ -1126,14 +1113,12 @@ fn distribution() {
     // 2 tokens to users[0] via validators[1] (~0.5 leftover)
     // 7 tokens to users[1] via validators[1] (~0.5 lefover)
     contract
-        .distribute_rewards(validators[0].to_owned())
-        .with_funds(&coins(10, STAR))
+        .distribute_rewards(validators[0].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 
     contract
-        .distribute_rewards(validators[1].to_owned())
-        .with_funds(&coins(10, STAR))
+        .distribute_rewards(validators[1].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 
@@ -1160,26 +1145,28 @@ fn distribution() {
 
     // And try to withdraw all, previous balances:
     contract
-        .withdraw_rewards(validators[0].to_string())
+        .withdraw_rewards(validators[0].to_string(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[1].to_string())
+        .withdraw_rewards(validators[1].to_string(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[0].to_string())
+        .withdraw_rewards(validators[0].to_string(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
 
     contract
-        .withdraw_rewards(validators[1].to_string())
+        .withdraw_rewards(validators[1].to_string(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
 
-    // Varyfying accounts, previous states:
+    // TODO: update to use IBC packet updates
+    /*
+    // Verifying accounts, previous states:
     // 127 on users[0] - now withdrawn 6 from validators[0] and 2 from validators[1]
     // 72 on users[1] - now withdrawn 33 from validators[0] and 37 from validators[1]
     assert_eq!(
@@ -1212,4 +1199,5 @@ fn distribution() {
             .u128(),
         2
     );
+    */
 }

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -282,11 +282,7 @@ fn staking() {
 #[track_caller]
 fn get_last_external_staking_pending_tx_id(contract: &ExternalStakingContractProxy) -> Option<u64> {
     let txs = contract.all_pending_txs_desc(None, None).unwrap().txs;
-    txs.first().map(|tx| match tx {
-        Tx::InFlightStaking { id, .. } => *id,
-        Tx::InFlightRemoteStaking { id, .. } => *id,
-        Tx::InFlightRemoteUnstaking { id, .. } => *id,
-    })
+    txs.first().map(Tx::id)
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -773,9 +773,19 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_owned(), remote[0].to_owned())
+        .call(users[0])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
 
@@ -783,11 +793,20 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_owned(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
-
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
-        .withdraw_rewards(validators[1].to_owned(), remote[1].to_owned())
+        .test_commit_withdraw_rewards(tx_id)
         .call(users[1])
         .unwrap();
+
+    // error if 0 rewards available
+    let err = contract
+        .withdraw_rewards(validators[1].to_owned(), remote[1].to_owned())
+        .call(users[1])
+        .unwrap_err();
+    assert_eq!(err, ContractError::NoRewards);
+    let tx_id = get_last_external_staking_pending_tx_id(&contract);
+    assert_eq!(tx_id, None);
 
     // Rewards should not be withdrawable anymore
     let rewards = contract
@@ -1039,10 +1058,31 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_owned(), remote[0].to_owned())
         .call(users[0])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
+
+    // Rollback on users[1]
+    contract
+        .withdraw_rewards(validators[0].to_owned(), "bad_value".to_owned())
+        .call(users[1])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_rollback_withdraw_rewards(tx_id)
+        .call(users[1])
         .unwrap();
 
     // Check withdrawals and accounts
@@ -1144,9 +1184,19 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_string(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_string(), remote[0].to_owned())
+        .call(users[0])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
 
@@ -1154,10 +1204,20 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_string(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_string(), remote[1].to_owned())
         .call(users[1])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
         .unwrap();
 
     // TODO: update to use IBC packet updates

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -451,11 +451,7 @@ fn stake_local() {
 #[track_caller]
 fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
     let txs = vault.all_pending_txs_desc(None, None).unwrap().txs;
-    txs.first().map(|tx| match tx {
-        Tx::InFlightStaking { id, .. } => *id,
-        Tx::InFlightRemoteStaking { id, .. } => *id,
-        Tx::InFlightRemoteUnstaking { id, .. } => *id,
-    })
+    txs.first().map(Tx::id)
 }
 
 #[test]

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -34,10 +34,8 @@ pub enum ProviderPacket {
         rewards: Coin,
         /// A valid address on the consumer chain to receive these rewards
         recipient: String,
-        /// Staker and validator are only used to revert the tx on the provider side.
-        /// TODO: make a proper pending tx type and use a tx_id here
-        staker: String,
-        validator: String,
+        /// This is local to the sending side to track the transaction, should be passed through opaquely on the consumer
+        tx_id: u64,
     },
 }
 

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -34,9 +34,10 @@ pub enum ProviderPacket {
         rewards: Coin,
         /// A valid address on the consumer chain to receive these rewards
         recipient: String,
-        /// A valid address on the provider chain where these rewards come from.
-        /// This is used to revert the transaction on error ack or timeout.
+        /// Staker and validator are only used to revert the tx on the provider side.
+        /// TODO: make a proper pending tx type and use a tx_id here
         staker: String,
+        validator: String,
     },
 }
 

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -28,6 +28,16 @@ pub enum ProviderPacket {
         /// This is local to the sending side to track the transaction, should be passed through opaquely on the consumer
         tx_id: u64,
     },
+    /// This is part of the rewards protocol
+    TransferRewards {
+        /// Amount previously received by ConsumerPacket::Distribute
+        rewards: Coin,
+        /// A valid address on the consumer chain to receive these rewards
+        recipient: String,
+        /// A valid address on the provider chain where these rewards come from.
+        /// This is used to revert the transaction on error ack or timeout.
+        staker: String,
+    },
 }
 
 /// Ack sent for ProviderPacket::Stake
@@ -44,6 +54,10 @@ pub struct UnstakeAck {
     pub tx_id: u64,
 }
 
+/// Ack sent for ProviderPacket::TransferRewards
+#[cw_serde]
+pub struct TransferRewardsAck {}
+
 /// These are messages sent from consumer -> provider
 /// ibc_packet_receive in external-staking must handle them all.
 #[cw_serde]
@@ -56,6 +70,15 @@ pub enum ConsumerPacket {
     /// but when it is no longer a valid target to delegate to.
     /// It contains a list of `valoper_address` to be removed
     RemoveValidators(Vec<String>),
+    /*
+    /// This is part of the rewards protocol
+    Distribute {
+        /// The validator whose stakers should receive these rewards
+        validator: String,
+        /// The amount of rewards held on the consumer side to be released later
+        rewards: Coin,
+    },
+    */
 }
 
 #[cw_serde]
@@ -86,8 +109,12 @@ pub struct AddValidatorsAck {}
 #[cw_serde]
 pub struct RemoveValidatorsAck {}
 
+/// Ack sent for ConsumerPacket::Distribute
+#[cw_serde]
+pub struct DistributeAck {}
+
 /// This is a generic ICS acknowledgement format.
-/// Proto defined here: https://github.com/cosmos/cosmos-sdk/blob/v0.42.0/proto/ibc/core/channel/v1/channel.proto#L141-L147
+/// Protobuf defined here: https://github.com/cosmos/cosmos-sdk/blob/v0.42.0/proto/ibc/core/channel/v1/channel.proto#L141-L147
 /// This is compatible with the JSON serialization.
 /// Wasmd uses this same wrapper for unhandled errors.
 #[cw_serde]

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -70,7 +70,6 @@ pub enum ConsumerPacket {
     /// but when it is no longer a valid target to delegate to.
     /// It contains a list of `valoper_address` to be removed
     RemoveValidators(Vec<String>),
-    /*
     /// This is part of the rewards protocol
     Distribute {
         /// The validator whose stakers should receive these rewards
@@ -78,7 +77,6 @@ pub enum ConsumerPacket {
         /// The amount of rewards held on the consumer side to be released later
         rewards: Coin,
     },
-    */
 }
 
 #[cw_serde]

--- a/packages/sync/src/txs.rs
+++ b/packages/sync/src/txs.rs
@@ -37,47 +37,33 @@ pub enum Tx {
         user: Addr,
         /// Remote validator
         validator: String,
-    }, // TODO
-       // InFlightSlashing
+    },
+    /// This is stored on the provider side when releasing funds
+    InFlightTransferFunds {
+        id: u64,
+        /// Amount of rewards being withdrawn
+        amount: Uint128,
+        /// The staker sending the funds
+        staker: Addr,
+        /// The validator whose rewards they come from (to revert)
+        validator: String,
+    }, // InFlightSlashing
 }
 
-// Implement display for Tx
+impl Tx {
+    pub fn id(&self) -> u64 {
+        match self {
+            Tx::InFlightStaking { id, .. } => *id,
+            Tx::InFlightRemoteStaking { id, .. } => *id,
+            Tx::InFlightRemoteUnstaking { id, .. } => *id,
+            Tx::InFlightTransferFunds { id, .. } => *id,
+        }
+    }
+}
+
+// Use Debug output for display as well (simplify the previous hand-coding of that)
 impl std::fmt::Display for Tx {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Tx::InFlightStaking {
-                id,
-                amount,
-                slashable,
-                user,
-                lienholder,
-            } => {
-                write!(f, "InFlightStaking {{ id: {}, amount: {}, slashable: {}, user: {}, lienholder: {} }}", id, amount, slashable, user, lienholder)
-            }
-            Tx::InFlightRemoteStaking {
-                id,
-                amount,
-                user,
-                validator,
-            } => {
-                write!(
-                    f,
-                    "InFlightRemoteStaking {{ id: {}, amount: {}, user: {}, validator: {} }}",
-                    id, amount, user, validator
-                )
-            }
-            Tx::InFlightRemoteUnstaking {
-                id,
-                amount,
-                user,
-                validator,
-            } => {
-                write!(
-                    f,
-                    "InFlightRemoteUnstaking {{ id: {}, amount: {}, user: {}, validator: {} }}",
-                    id, amount, user, validator
-                )
-            }
-        }
+        write!(f, "{:?}", self)
     }
 }


### PR DESCRIPTION
- [x] Virtual staking send rewards to converter on epoch withdrawals
- [x] Converter stores rewards and sends information over IBC to external-staking
- [x] Converter releases tokens to desired address on response ibc-packet
- [x] Update external-staking to handle this info, not coin payments
- [x] external-staking sends IBC packet on withdraw rewards 
- [x] Handle reverting transfer on error ack / timeout
- [x] Update docs to show which approach we selected (for MVP)

later: 
- Figure out how to multi-test (or future PR and test in Go?) - see https://github.com/osmosis-labs/mesh-security/pull/73 as to what is blocking