### PR TITLE
Ensure validators are registered before staking

### DIFF
--- a/contracts/provider/external-staking/src/error.rs
+++ b/contracts/provider/external-staking/src/error.rs
@@ -33,8 +33,11 @@ pub enum ContractError {
     #[error("Not enough tokens released, up to {0} can be claimed")]
     NotEnoughRelease(Uint128),
 
-    #[error("Validator for user missmatch, {0} expected")]
+    #[error("Validator for user mismatch, {0} expected")]
     InvalidValidator(String),
+
+    #[error("Cannot stake to {0}, not listed as an active validator on consumer")]
+    ValidatorNotActive(String),
 
     #[error("Contract already has an open IBC channel")]
     IbcChannelAlreadyOpen,

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1,6 +1,7 @@
 use anyhow::Result as AnyResult;
 
 use cosmwasm_std::{coin, coins, to_binary, Addr, Decimal};
+use mesh_apis::ibc::AddValidator;
 use mesh_native_staking::contract::multitest_utils::CodeId as NativeStakingCodeId;
 use mesh_native_staking::contract::InstantiateMsg as NativeStakingInstantiateMsg;
 use mesh_native_staking_proxy::contract::multitest_utils::CodeId as NativeStakingProxyCodeId;
@@ -102,6 +103,15 @@ fn staking() {
 
     let (vault, contract) = setup(&app, owner, 100).unwrap();
 
+    // set these validators to be active
+    for val in validators {
+        let activate = AddValidator::mock(val);
+        contract
+            .test_set_active_validator(activate)
+            .call("test")
+            .unwrap();
+    }
+
     // Bond tokens
     vault
         .bond()
@@ -114,6 +124,23 @@ fn staking() {
         .with_funds(&coins(300, OSMO))
         .call(users[1])
         .unwrap();
+
+    /*
+    // Fail to stake on non-registered validator
+    let msg = to_binary(&ReceiveVirtualStake {
+        validator: "unknown".to_string(),
+    })
+    .unwrap();
+    println!("START");
+    // FIXME: Sylvia panics here, with this line in ExecProxy::call
+    //             .map_err(|err| err.downcast().unwrap())
+    // Note that the error didn't happen in vault, but in a SubMsg, so this should be some StdError not ContractError...
+    let res = vault
+        .stake_remote(contract.contract_addr.to_string(), coin(100, OSMO), msg)
+        .call(users[0]);
+    println!("GOT: {:?}", res);
+    assert!(res.is_err());
+    */
 
     // Perform couple stakes
     // users[0] stakes 200 on validators[0] in 2 batches
@@ -310,6 +337,15 @@ fn unstaking() {
     let validators = ["validator1", "validator2"];
 
     let (vault, contract) = setup(&app, owner, 100).unwrap();
+
+    // set these validators to be active
+    for val in validators {
+        let activate = AddValidator::mock(val);
+        contract
+            .test_set_active_validator(activate)
+            .call("test")
+            .unwrap();
+    }
 
     // Bond and stake tokens
     //
@@ -625,6 +661,15 @@ fn distribution() {
     let validators = ["validator1", "validator2"];
 
     let (vault, contract) = setup(&app, owner, 100).unwrap();
+
+    // set these validators to be active
+    for val in validators {
+        let activate = AddValidator::mock(val);
+        contract
+            .test_set_active_validator(activate)
+            .call("test")
+            .unwrap();
+    }
 
     // Bond and stake tokens
     //

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -78,6 +78,17 @@ pub struct AddValidator {
     pub start_time: u64,
 }
 
+impl AddValidator {
+    pub fn mock(valoper: &str) -> Self {
+        Self {
+            valoper: valoper.to_string(),
+            pub_key: "mock-pubkey".to_string(),
+            start_height: 12345,
+            start_time: 1687357499,
+        }
+    }
+}
+
 /// Ack sent for ConsumerPacket::AddValidators
 #[cw_serde]
 pub struct AddValidatorsAck {}


### PR DESCRIPTION
Closes #70 

This doesn't let a new stake occur unless when know the validator is in the active set.
Added a test command to place a validator in the active set.
