### PR TITLE
Reward payments 1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
 # 0.3.0-beta
 
-* IBC specification is added to the documents.
-* IBC types and logic added to `mesh-api::ibc`
-* `converter` and `external-staking` support ibc
-    * Handshake and channel creation
-    * Validator sync protocol (Consumer -> Provider)
-    * WIP: Staking protocol (Provider -> Consumer)
-    * TODO: Reward protocol (Consumer -> Provider)
+- IBC specification is added to the documents.
+- IBC types and logic added to `mesh-api::ibc`
+- `converter` and `external-staking` support ibc
+  - Handshake and channel creation
+  - Validator sync protocol (Consumer -> Provider)
+  - WIP: Staking protocol (Provider -> Consumer)
+  - TODO: Reward protocol (Consumer -> Provider)

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    ensure_eq, to_binary, Addr, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, Reply, Response,
-    SubMsg, SubMsgResponse, WasmMsg, BankMsg,
+    ensure_eq, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, Reply,
+    Response, SubMsg, SubMsgResponse, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Item;

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -58,7 +58,7 @@ impl ConverterContract<'_> {
         admin: Option<String>,
     ) -> Result<Response, ContractError> {
         nonpayable(&ctx.info)?;
-        // valdiate args
+        // validate args
         if discount > Decimal::one() {
             return Err(ContractError::InvalidDiscount);
         }

--- a/contracts/consumer/converter/src/error.rs
+++ b/contracts/consumer/converter/src/error.rs
@@ -31,4 +31,10 @@ pub enum ContractError {
 
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
+
+    #[error("Invalid discount, must be between 0.0 and 1.0")]
+    InvalidDiscount,
+
+    #[error("Invalid denom: {0}")]
+    InvalidDenom(String),
 }

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -185,9 +185,7 @@ pub fn ibc_packet_receive(
                 .add_attributes(response.attributes)
         }
         ProviderPacket::TransferRewards {
-            rewards,
-            recipient,
-            staker: _,
+            rewards, recipient, ..
         } => {
             let msg = contract.transfer_rewards(deps.as_ref(), recipient, rewards)?;
             let ack = ack_success(&TransferRewardsAck {})?;

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -11,7 +11,7 @@ use cw_storage_plus::Item;
 
 use mesh_apis::ibc::{
     ack_success, validate_channel_order, AckWrapper, AddValidator, ConsumerPacket, ProtocolVersion,
-    ProviderPacket, StakeAck, UnstakeAck, PROTOCOL_NAME,
+    ProviderPacket, StakeAck, TransferRewardsAck, UnstakeAck, PROTOCOL_NAME,
 };
 
 use crate::{contract::ConverterContract, error::ContractError};
@@ -174,6 +174,15 @@ pub fn ibc_packet_receive(
                 .add_submessages(response.messages)
                 .add_events(response.events)
                 .add_attributes(response.attributes)
+        }
+        ProviderPacket::TransferRewards {
+            rewards,
+            recipient,
+            staker: _,
+        } => {
+            let msg = contract.transfer_rewards(deps.as_ref(), recipient, rewards)?;
+            let ack = ack_success(&TransferRewardsAck {})?;
+            IbcReceiveResponse::new().set_ack(ack).add_message(msg)
         }
     };
     Ok(res)

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -22,12 +22,12 @@ const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "0.10.0";
 const MIN_IBC_PROTOCOL_VERSION: &str = "0.10.0";
 
 // IBC specific state
-const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
+pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
 
 // Let those validator syncs take a day...
 const DEFAULT_TIMEOUT: u64 = 24 * 60 * 60;
 
-fn packet_timeout(env: &Env) -> IbcTimeout {
+pub fn packet_timeout(env: &Env) -> IbcTimeout {
     // No idea about their blocktime, but 24 hours ahead of our view of the clock
     // should be decently in the future.
     let timeout = env.block.time.plus_seconds(DEFAULT_TIMEOUT);

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -25,12 +25,21 @@ const MIN_IBC_PROTOCOL_VERSION: &str = "0.10.0";
 pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
 
 // Let those validator syncs take a day...
-const DEFAULT_TIMEOUT: u64 = 24 * 60 * 60;
+const DEFAULT_VALIDATOR_TIMEOUT: u64 = 24 * 60 * 60;
+// But reward messages should go faster or timeout
+const DEFAULT_REWARD_TIMEOUT: u64 = 60 * 60;
 
-pub fn packet_timeout(env: &Env) -> IbcTimeout {
+pub fn packet_timeout_validator(env: &Env) -> IbcTimeout {
     // No idea about their blocktime, but 24 hours ahead of our view of the clock
     // should be decently in the future.
-    let timeout = env.block.time.plus_seconds(DEFAULT_TIMEOUT);
+    let timeout = env.block.time.plus_seconds(DEFAULT_VALIDATOR_TIMEOUT);
+    IbcTimeout::with_timestamp(timeout)
+}
+
+pub fn packet_timeout_rewards(env: &Env) -> IbcTimeout {
+    // No idea about their blocktime, but 1 hour ahead of our view of the clock
+    // should be decently in the future.
+    let timeout = env.block.time.plus_seconds(DEFAULT_REWARD_TIMEOUT);
     IbcTimeout::with_timestamp(timeout)
 }
 
@@ -120,7 +129,7 @@ pub fn ibc_channel_connect(
     let msg = IbcMsg::SendPacket {
         channel_id: channel.endpoint.channel_id,
         data: to_binary(&packet)?,
-        timeout: packet_timeout(&env),
+        timeout: packet_timeout_validator(&env),
     };
 
     Ok(IbcBasicResponse::new().add_message(msg))
@@ -225,7 +234,7 @@ pub fn ibc_packet_timeout(
     let msg = IbcMsg::SendPacket {
         channel_id: msg.packet.src.channel_id,
         data: msg.packet.data,
-        timeout: packet_timeout(&env),
+        timeout: packet_timeout_validator(&env),
     };
     Ok(IbcBasicResponse::new().add_message(msg))
 }

--- a/contracts/consumer/virtual-staking/src/error.rs
+++ b/contracts/consumer/virtual-staking/src/error.rs
@@ -18,4 +18,7 @@ pub enum ContractError {
 
     #[error("Cannot unbond {1} tokens from validator {0}, not enough staked")]
     InsufficientBond(String, Uint128),
+
+    #[error("Invalid Reply ID. Don't recognize {0}")]
+    InvalidReplyId(u64),
 }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -555,7 +555,7 @@ impl ExternalStakingContract<'_> {
     }
 
     #[msg(exec)]
-    pub fn distribute_rewards(
+    pub fn test_distribute_rewards(
         &self,
         ctx: ExecCtx,
         validator: String,
@@ -563,7 +563,7 @@ impl ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(test)]
         {
-            let event = self.do_distribute_rewards(ctx.deps, validator, rewards)?;
+            let event = self.distribute_rewards(ctx.deps, validator, rewards)?;
             Ok(Response::new().add_event(event))
         }
         #[cfg(not(test))]
@@ -575,8 +575,8 @@ impl ExternalStakingContract<'_> {
 
     /// Distributes reward among users staking via particular validator. Distribution is performed
     /// proportionally to amount of tokens staked by user.
-    /// This is called by IBC packets in real code, but also exposed in a test only message "distribute_rewards"
-    pub(crate) fn do_distribute_rewards(
+    /// This is called by IBC packets in real code, but also exposed in a test only message "test_distribute_rewards"
+    pub(crate) fn distribute_rewards(
         &self,
         deps: DepsMut,
         validator: String,

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -355,7 +355,8 @@ impl ExternalStakingContract<'_> {
             data: to_binary(&packet)?,
             timeout: packet_timeout(&ctx.env),
         };
-        // send packet if we are ibc enabled (skip in tests)
+        // send packet if we are ibc enabled
+        // TODO: send in test code when we can handle it
         #[cfg(not(test))]
         {
             resp = resp.add_message(msg);
@@ -750,13 +751,10 @@ impl ExternalStakingContract<'_> {
         self.pending_txs.remove(deps.storage, tx_id);
 
         // Verify tx is of the right type and get data
-        let (_amount, staker, validator) = match tx {
+        let (staker, validator) = match tx {
             Tx::InFlightTransferFunds {
-                amount,
-                staker,
-                validator,
-                ..
-            } => (amount, staker, validator),
+                staker, validator, ..
+            } => (staker, validator),
             _ => {
                 return Err(ContractError::WrongTypeTx(tx_id, tx));
             }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1,32 +1,31 @@
 use cosmwasm_std::{
-    coin, ensure, ensure_eq, from_binary, Addr, Binary, Coin, Decimal, DepsMut, Env, Event, Order,
-    Response, StdError, StdResult, Storage, Uint128, Uint256, WasmMsg,
+    coin, ensure, ensure_eq, from_binary, to_binary, Addr, Binary, Coin, Decimal, DepsMut, Env,
+    Event, IbcMsg, Order, Response, StdError, StdResult, Storage, Uint128, Uint256, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Bounder, Item, Map};
 use cw_utils::PaymentError;
-use mesh_apis::cross_staking_api::{self, CrossStakingApi};
-use mesh_apis::ibc::AddValidator;
-use mesh_apis::local_staking_api::MaxSlashResponse;
-use mesh_apis::vault_api::VaultApiHelper;
-use mesh_sync::Lockable;
-
-use crate::crdt::CrdtState;
-use crate::ibc::{packet_timeout, IBC_CHANNEL};
-use cosmwasm_std::{to_binary, IbcMsg};
-use mesh_apis::ibc::ProviderPacket;
 
 use sylvia::contract;
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
 
+use mesh_apis::cross_staking_api::{self, CrossStakingApi};
+use mesh_apis::ibc::AddValidator;
+use mesh_apis::ibc::ProviderPacket;
+use mesh_apis::local_staking_api::MaxSlashResponse;
+use mesh_apis::vault_api::VaultApiHelper;
+use mesh_sync::Lockable;
+use mesh_sync::Tx;
+
+use crate::crdt::CrdtState;
 use crate::error::ContractError;
+use crate::ibc::{packet_timeout, IBC_CHANNEL};
 use crate::msg::{
     AllPendingRewards, AllTxsResponse, AuthorizedEndpointResponse, ConfigResponse,
     IbcChannelResponse, ListRemoteValidatorsResponse, PendingRewards, ReceiveVirtualStake,
     StakeInfo, StakesResponse, TxResponse, ValidatorPendingReward,
 };
 use crate::state::{Config, Distribution, Stake};
-use mesh_sync::Tx;
 
 pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/contracts/provider/external-staking/src/error.rs
+++ b/contracts/provider/external-staking/src/error.rs
@@ -53,4 +53,7 @@ pub enum ContractError {
 
     #[error("The tx {0} exists but is of the wrong type: {1}")]
     WrongTypeTx(u64, Tx),
+
+    #[error("No staking rewards to be withdrawn")]
+    NoRewards,
 }

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -153,7 +153,7 @@ pub fn ibc_packet_receive(
         }
         ConsumerPacket::Distribute { validator, rewards } => {
             let contract = ExternalStakingContract::new();
-            let evt = contract.do_distribute_rewards(deps, validator, rewards)?;
+            let evt = contract.distribute_rewards(deps, validator, rewards)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -203,7 +203,7 @@ pub fn ibc_packet_ack(
                 .add_attribute("tx_id", tx_id.to_string());
         }
         (ProviderPacket::TransferRewards { tx_id, .. }, AckWrapper::Result(_)) => {
-            // Any events to add?
+            // TODO: Any events to add?
             contract.commit_withdraw_rewards(deps, tx_id)?;
         }
         (ProviderPacket::TransferRewards { tx_id, .. }, AckWrapper::Error(e)) => {
@@ -213,16 +213,6 @@ pub fn ibc_packet_ack(
                 .add_attribute("packet", msg.original_packet.sequence.to_string());
         }
     }
-
-    // Question: do we need a special event with all this info on error?
-
-    //         // Provide info to find the actual packet.
-    //         let event = Event::new("mesh_ibc_error")
-    //             .add_attribute("error", e)
-    //             .add_attribute("channel", msg.original_packet.src.channel_id)
-    //             .add_attribute("sequence", msg.original_packet.sequence.to_string());
-    //         resp = resp.add_event(event);
-    //     }
     Ok(resp)
 }
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -756,14 +756,14 @@ fn distribution() {
     // 20 tokens for users[0]
     // 30 tokens for users[1]
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(50, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(50, STAR))
         .call(owner)
         .unwrap();
 
     // Only users[0] stakes on validators[1]
     // 30 tokens for users[0]
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(30, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(30, STAR))
         .call(owner)
         .unwrap();
 
@@ -819,13 +819,13 @@ fn distribution() {
     // 42 tokens for users[1]
     // 1 token is not distributed
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(71, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(71, STAR))
         .call(owner)
         .unwrap();
 
     // Distribution in invalid coin should fail
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(100, OSMO))
+        .test_distribute_rewards(validators[1].to_owned(), coin(100, OSMO))
         .call(owner)
         .unwrap_err();
 
@@ -922,7 +922,7 @@ fn distribution() {
     //
     // The additional 1 token is leftover after previous allocation
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(9, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(9, STAR))
         .call(owner)
         .unwrap();
 
@@ -942,7 +942,7 @@ fn distribution() {
     // 4 on users[0] (+ ~0.4)
     // 6 on users[1] (+ ~0.6)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(11, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
 
@@ -950,7 +950,7 @@ fn distribution() {
     //
     // 11 on users[0]
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(11, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
 
@@ -1015,7 +1015,7 @@ fn distribution() {
     // 10 on users[0] (~0.4 still not distributed)
     // 10 on users[1] (~0.6 still not distributed)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(20, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(20, STAR))
         .call(owner)
         .unwrap();
 
@@ -1023,7 +1023,7 @@ fn distribution() {
     // 10 on users[1]
     // 30 on users[2]
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(40, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(40, STAR))
         .call(owner)
         .unwrap();
 
@@ -1054,7 +1054,7 @@ fn distribution() {
     // 3 for users[1] (+ ~0.5 from this distribution + ~0.6 accumulated -> ~1.1 tokens, we give one
     //   back leaving ~0.1 accumulated)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(5, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(5, STAR))
         .call(owner)
         .unwrap();
 
@@ -1102,7 +1102,7 @@ fn distribution() {
     // 7 + 1 = 8 to users[0] (~0.9 accumulated + ~0.2 = ~1.1 leftover, 1.0 payed back, ~0.1 accumulated)
     // 4 to users[0] (~0.1 accumulated + ~0.8 -> leaving at ~0.9)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(12, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(12, STAR))
         .call(owner)
         .unwrap();
 
@@ -1191,12 +1191,12 @@ fn distribution() {
     // 2 tokens to users[0] via validators[1] (~0.5 leftover)
     // 7 tokens to users[1] via validators[1] (~0.5 lefover)
     contract
-        .distribute_rewards(validators[0].to_owned(), coin(10, STAR))
+        .test_distribute_rewards(validators[0].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 
     contract
-        .distribute_rewards(validators[1].to_owned(), coin(10, STAR))
+        .test_distribute_rewards(validators[1].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -800,16 +800,6 @@ fn distribution() {
     let expected = vec![ValidatorPendingReward::new(validators[0], 30, STAR)];
     assert_eq!(all_rewards.rewards, expected);
 
-    // TODO: add new IBC-enabled form
-    // Distributed funds should be on the staking contract
-    // assert_eq!(
-    //     app.app()
-    //         .wrap()
-    //         .query_all_balances(contract.contract_addr.clone())
-    //         .unwrap(),
-    //     coins(80, STAR)
-    // );
-
     // Some more distribution, this time not divisible by total staken tokens
     // 28 tokens for users[0]
     // 42 tokens for users[1]
@@ -907,31 +897,7 @@ fn distribution() {
         .unwrap();
     assert_eq!(rewards.amount.amount.u128(), 0);
 
-    // TODO: change this to somehow assert ibc packets
-    /*
-    // Rewards should be on users accounts
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(users[0], STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        78
-    );
-
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(users[1], STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        72
-    );
-    */
-
-    // Anothed distribution - making it equal
+    // Another distribution - making it equal
     // 4 on users[0]
     // 6 on users[1]
     //
@@ -1184,43 +1150,6 @@ fn distribution() {
         .unwrap();
     assert_eq!(rewards.amount.amount.u128(), 30);
 
-    // TODO: update for IBC
-    // Balances was previously:
-    // 78 on users[0] - now witdrawing 28 from validators[0] and 21 from validators[1]
-    // 72 on users[1] - should be the same
-    /*
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(users[0], STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        127
-    );
-
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(users[1], STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        72
-    );
-
-    // On contract we keep 59 to be withdrawn by users[1] + 1 token of leftover
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(contract.contract_addr.to_string(), STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        60
-    );
-    */
-
     // Final distribution - 10 tokens to both validators
     // 6 tokens to users[0] via validators[0] (leftover as it was)
     // 4 tokens to users[1] via validators[0] (leftover as it was)
@@ -1315,41 +1244,4 @@ fn distribution() {
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
-
-    // TODO: update to use IBC packet updates
-    /*
-    // Verifying accounts, previous states:
-    // 127 on users[0] - now withdrawn 6 from validators[0] and 2 from validators[1]
-    // 72 on users[1] - now withdrawn 33 from validators[0] and 37 from validators[1]
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(users[0], STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        135
-    );
-
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(users[1], STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        142
-    );
-
-    // Both distributions have leftover - 2 tokens accumulated on staking contract
-    assert_eq!(
-        app.app()
-            .wrap()
-            .query_balance(contract.contract_addr.to_string(), STAR.to_owned())
-            .unwrap()
-            .amount
-            .u128(),
-        2
-    );
-    */
 }

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -316,11 +316,7 @@ fn staking() {
 #[track_caller]
 fn get_last_external_staking_pending_tx_id(contract: &ExternalStakingContractProxy) -> Option<u64> {
     let txs = contract.all_pending_txs_desc(None, None).unwrap().txs;
-    txs.first().map(|tx| match tx {
-        Tx::InFlightStaking { id, .. } => *id,
-        Tx::InFlightRemoteStaking { id, .. } => *id,
-        Tx::InFlightRemoteUnstaking { id, .. } => *id,
-    })
+    txs.first().map(Tx::id)
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -851,9 +851,19 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_owned(), remote[0].to_owned())
+        .call(users[0])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
 
@@ -861,11 +871,20 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_owned(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
-
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
-        .withdraw_rewards(validators[1].to_owned(), remote[1].to_owned())
+        .test_commit_withdraw_rewards(tx_id)
         .call(users[1])
         .unwrap();
+
+    // error if 0 rewards available
+    let err = contract
+        .withdraw_rewards(validators[1].to_owned(), remote[1].to_owned())
+        .call(users[1])
+        .unwrap_err();
+    assert_eq!(err, ContractError::NoRewards);
+    let tx_id = get_last_external_staking_pending_tx_id(&contract);
+    assert_eq!(tx_id, None);
 
     // Rewards should not be withdrawable anymore
     let rewards = contract
@@ -1117,10 +1136,31 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_owned(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_owned(), remote[0].to_owned())
         .call(users[0])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
+
+    // Rollback on users[1]
+    contract
+        .withdraw_rewards(validators[0].to_owned(), "bad_value".to_owned())
+        .call(users[1])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_rollback_withdraw_rewards(tx_id)
+        .call(users[1])
         .unwrap();
 
     // Check withdrawals and accounts
@@ -1240,9 +1280,19 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_string(), remote[0].to_owned())
         .call(users[0])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_string(), remote[0].to_owned())
+        .call(users[0])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
 
@@ -1250,10 +1300,20 @@ fn distribution() {
         .withdraw_rewards(validators[0].to_string(), remote[1].to_owned())
         .call(users[1])
         .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
+        .unwrap();
 
     contract
         .withdraw_rewards(validators[1].to_string(), remote[1].to_owned())
         .call(users[1])
+        .unwrap();
+    let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
+    contract
+        .test_commit_withdraw_rewards(tx_id)
+        .call(users[0])
         .unwrap();
 
     // TODO: update to use IBC packet updates

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -451,11 +451,7 @@ fn stake_local() {
 #[track_caller]
 fn get_last_pending_tx_id(vault: &VaultContractProxy) -> Option<u64> {
     let txs = vault.all_pending_txs_desc(None, None).unwrap().txs;
-    txs.first().map(|tx| match tx {
-        Tx::InFlightStaking { id, .. } => *id,
-        Tx::InFlightRemoteStaking { id, .. } => *id,
-        Tx::InFlightRemoteUnstaking { id, .. } => *id,
-    })
+    txs.first().map(Tx::id)
 }
 
 #[test]

--- a/docs/ibc/Rewards.md
+++ b/docs/ibc/Rewards.md
@@ -147,7 +147,7 @@ that should be distributed among all stakers on the given validators. It is up t
 must guarantee to hold `rewards` tokens in reserve to be released by future IBC packets
 on this channel.
 
-The provider side has a new variant `ProviderPacket::TransferFunds {}` which specifies the
+The provider side has a new variant `ProviderPacket::TransferRewards {}` which specifies the
 among and the recipient address on the consumer chain. If the converter contract hold those
 tokens in reserve (always in the case of a correct provider chain), it must release
 them to the given address. The consumer chain must be designed to handle rollbacks here

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -64,7 +64,6 @@ pub enum ConsumerPacket {
     /// but when it is no longer a valid target to delegate to.
     /// It contains a list of `valoper_address` to be removed
     RemoveValidators(Vec<String>),
-    /*
     /// This is part of the rewards protocol
     Distribute {
         /// The validator whose stakers should receive these rewards
@@ -72,7 +71,6 @@ pub enum ConsumerPacket {
         /// The amount of rewards held on the consumer side to be released later
         rewards: Coin,
     },
-    */
 }
 
 #[cw_serde]

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -34,10 +34,8 @@ pub enum ProviderPacket {
         rewards: Coin,
         /// A valid address on the consumer chain to receive these rewards
         recipient: String,
-        /// Staker and validator are only used to revert the tx on the provider side.
-        /// TODO: make a proper pending tx type and use a tx_id here
-        staker: String,
-        validator: String,
+        /// This is local to the sending side to track the transaction, should be passed through opaquely on the consumer
+        tx_id: u64,
     },
 }
 

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -28,6 +28,16 @@ pub enum ProviderPacket {
         /// This is local to the sending side to track the transaction, should be passed through opaquely on the consumer
         tx_id: u64,
     },
+    /// This is part of the rewards protocol
+    TransferRewards {
+        /// Amount previously received by ConsumerPacket::Distribute
+        rewards: Coin,
+        /// A valid address on the consumer chain to receive these rewards
+        recipient: String,
+        /// A valid address on the provider chain where these rewards come from.
+        /// This is used to revert the transaction on error ack or timeout.
+        staker: String,
+    },
 }
 
 /// Ack sent for ProviderPacket::Stake
@@ -37,6 +47,10 @@ pub struct StakeAck {}
 /// Ack sent for ProviderPacket::Unstake
 #[cw_serde]
 pub struct UnstakeAck {}
+
+/// Ack sent for ProviderPacket::TransferRewards
+#[cw_serde]
+pub struct TransferRewardsAck {}
 
 /// These are messages sent from consumer -> provider
 /// ibc_packet_receive in external-staking must handle them all.
@@ -50,6 +64,15 @@ pub enum ConsumerPacket {
     /// but when it is no longer a valid target to delegate to.
     /// It contains a list of `valoper_address` to be removed
     RemoveValidators(Vec<String>),
+    /*
+    /// This is part of the rewards protocol
+    Distribute {
+        /// The validator whose stakers should receive these rewards
+        validator: String,
+        /// The amount of rewards held on the consumer side to be released later
+        rewards: Coin,
+    },
+    */
 }
 
 #[cw_serde]
@@ -91,8 +114,12 @@ pub struct AddValidatorsAck {}
 #[cw_serde]
 pub struct RemoveValidatorsAck {}
 
+/// Ack sent for ConsumerPacket::Distribute
+#[cw_serde]
+pub struct DistributeAck {}
+
 /// This is a generic ICS acknowledgement format.
-/// Proto defined here: https://github.com/cosmos/cosmos-sdk/blob/v0.42.0/proto/ibc/core/channel/v1/channel.proto#L141-L147
+/// Protobuf defined here: https://github.com/cosmos/cosmos-sdk/blob/v0.42.0/proto/ibc/core/channel/v1/channel.proto#L141-L147
 /// This is compatible with the JSON serialization.
 /// Wasmd uses this same wrapper for unhandled errors.
 #[cw_serde]

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -34,9 +34,10 @@ pub enum ProviderPacket {
         rewards: Coin,
         /// A valid address on the consumer chain to receive these rewards
         recipient: String,
-        /// A valid address on the provider chain where these rewards come from.
-        /// This is used to revert the transaction on error ack or timeout.
+        /// Staker and validator are only used to revert the tx on the provider side.
+        /// TODO: make a proper pending tx type and use a tx_id here
         staker: String,
+        validator: String,
     },
 }
 

--- a/packages/sync/src/txs.rs
+++ b/packages/sync/src/txs.rs
@@ -16,7 +16,6 @@ pub enum Tx {
         /// Remote staking contract
         lienholder: Addr,
     },
-    // IBC flight
     InFlightRemoteStaking {
         /// Transaction id
         id: u64,
@@ -27,7 +26,6 @@ pub enum Tx {
         /// Remote validator
         validator: String,
     },
-    // IBC flight
     InFlightRemoteUnstaking {
         /// Transaction id
         id: u64,
@@ -47,7 +45,7 @@ pub enum Tx {
         staker: Addr,
         /// The validator whose rewards they come from (to revert)
         validator: String,
-    }, // InFlightSlashing
+    },
 }
 
 impl Tx {

--- a/packages/sync/src/txs.rs
+++ b/packages/sync/src/txs.rs
@@ -37,47 +37,33 @@ pub enum Tx {
         user: Addr,
         /// Remote validator
         validator: String,
-    }, // TODO
-       // InFlightSlashing
+    },
+    /// This is stored on the provider side when releasing funds
+    InFlightTransferFunds {
+        id: u64,
+        /// Amount of rewards being withdrawn
+        amount: Uint128,
+        /// The staker sending the funds
+        staker: Addr,
+        /// The validator whose rewards they come from (to revert)
+        validator: String,
+    }, // InFlightSlashing
 }
 
-// Implement display for Tx
+impl Tx {
+    pub fn id(&self) -> u64 {
+        match self {
+            Tx::InFlightStaking { id, .. } => *id,
+            Tx::InFlightRemoteStaking { id, .. } => *id,
+            Tx::InFlightRemoteUnstaking { id, .. } => *id,
+            Tx::InFlightTransferFunds { id, .. } => *id,
+        }
+    }
+}
+
+// Use Debug output for display as well (simplify the previous hand-coding of that)
 impl std::fmt::Display for Tx {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Tx::InFlightStaking {
-                id,
-                amount,
-                slashable,
-                user,
-                lienholder,
-            } => {
-                write!(f, "InFlightStaking {{ id: {}, amount: {}, slashable: {}, user: {}, lienholder: {} }}", id, amount, slashable, user, lienholder)
-            }
-            Tx::InFlightRemoteStaking {
-                id,
-                amount,
-                user,
-                validator,
-            } => {
-                write!(
-                    f,
-                    "InFlightRemoteStaking {{ id: {}, amount: {}, user: {}, validator: {} }}",
-                    id, amount, user, validator
-                )
-            }
-            Tx::InFlightRemoteUnstaking {
-                id,
-                amount,
-                user,
-                validator,
-            } => {
-                write!(
-                    f,
-                    "InFlightRemoteUnstaking {{ id: {}, amount: {}, user: {}, validator: {} }}",
-                    id, amount, user, validator
-                )
-            }
-        }
+        write!(f, "{:?}", self)
     }
 }


### PR DESCRIPTION
Recreate from #69 after a mistaken merge and revert.

Enables rewards to be sent every epoch from consumer to producer and distributed to stakers.
Stakers can withdraw rewards to an account on the consumer chain (where they can be staked), with a message on the provider chain (which knows who staked)