### PR TITLE
Configure max slashable

### DIFF
--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -80,6 +80,7 @@ impl ExternalStakingContract<'_> {
         Ok(id)
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[msg(instantiate)]
     pub fn instantiate(
         &self,
@@ -89,15 +90,21 @@ impl ExternalStakingContract<'_> {
         vault: String,
         unbonding_period: u64,
         remote_contact: crate::msg::AuthorizedEndpoint,
+        max_slashing: Decimal,
     ) -> Result<Response, ContractError> {
         let vault = ctx.deps.api.addr_validate(&vault)?;
         let vault = VaultApiHelper(vault);
+
+        if max_slashing > Decimal::one() {
+            return Err(ContractError::InvalidMaxSlashing);
+        }
 
         let config = Config {
             denom,
             rewards_denom,
             vault,
             unbonding_period,
+            max_slashing,
         };
 
         self.config.save(ctx.deps.storage, &config)?;
@@ -899,16 +906,12 @@ pub mod cross_staking {
         }
 
         #[msg(query)]
-        fn max_slash(&self, _ctx: QueryCtx) -> Result<MaxSlashResponse, ContractError> {
-            // TODO: Properly set this value
-            // Arbitrary value - only to make some testing possible
-            //
-            // Probably should be queried from remote chain
-            let resp = MaxSlashResponse {
-                max_slash: Decimal::percent(5),
-            };
-
-            Ok(resp)
+        fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, ContractError> {
+            let Config {
+                max_slashing: max_slash,
+                ..
+            } = self.config.load(ctx.deps.storage)?;
+            Ok(MaxSlashResponse { max_slash })
         }
     }
 }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -907,11 +907,10 @@ pub mod cross_staking {
 
         #[msg(query)]
         fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, ContractError> {
-            let Config {
-                max_slashing: max_slash,
-                ..
-            } = self.config.load(ctx.deps.storage)?;
-            Ok(MaxSlashResponse { max_slash })
+            let Config { max_slashing, .. } = self.config.load(ctx.deps.storage)?;
+            Ok(MaxSlashResponse {
+                max_slash: max_slashing,
+            })
         }
     }
 }

--- a/contracts/provider/external-staking/src/error.rs
+++ b/contracts/provider/external-staking/src/error.rs
@@ -27,6 +27,9 @@ pub enum ContractError {
     #[error("Invalid denom, {0} expected")]
     InvalidDenom(String),
 
+    #[error("You cannot use a max slashing rate over 1.0 (100%)")]
+    InvalidMaxSlashing,
+
     #[error("Not enough tokens staked, up to {0} can be unbond")]
     NotEnoughStake(Uint128),
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -21,6 +21,8 @@ use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo};
 const OSMO: &str = "osmo";
 const STAR: &str = "star";
 
+const SLASHING_PERCENTAGE: u64 = 10;
+
 // Shortcut setuping all needed contracts
 //
 // Returns vault and external staking proxies
@@ -59,6 +61,7 @@ fn setup<'app>(
             vault.contract_addr.to_string(),
             unbond_period,
             remote_contact,
+            Decimal::percent(SLASHING_PERCENTAGE),
         )
         .call(owner)?;
 
@@ -78,7 +81,7 @@ fn instantiate() {
     assert_eq!(stakes.stakes, []);
 
     let max_slash = contract.cross_staking_api_proxy().max_slash().unwrap();
-    assert_eq!(max_slash.max_slash, Decimal::percent(5));
+    assert_eq!(max_slash.max_slash, Decimal::percent(SLASHING_PERCENTAGE));
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -21,7 +21,10 @@ use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo};
 const OSMO: &str = "osmo";
 const STAR: &str = "star";
 
+/// 10% slashing on the remote chain
 const SLASHING_PERCENTAGE: u64 = 10;
+/// 5% slashing on the local chain (so we can differentiate in future tests)
+const LOCAL_SLASHING_PERCENTAGE: u64 = 5;
 
 // Shortcut setuping all needed contracts
 //
@@ -39,7 +42,7 @@ fn setup<'app>(
     let native_staking_instantiate = NativeStakingInstantiateMsg {
         denom: OSMO.to_owned(),
         proxy_code_id: native_staking_proxy_code.code_id(),
-        max_slashing: Decimal::percent(5),
+        max_slashing: Decimal::percent(LOCAL_SLASHING_PERCENTAGE),
     };
 
     let staking_init = StakingInitInfo {

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -39,6 +39,7 @@ fn setup<'app>(
     let native_staking_instantiate = NativeStakingInstantiateMsg {
         denom: OSMO.to_owned(),
         proxy_code_id: native_staking_proxy_code.code_id(),
+        max_slashing: Decimal::percent(5),
     };
 
     let staking_init = StakingInitInfo {

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{BlockInfo, Timestamp, Uint128, Uint256};
+use cosmwasm_std::{BlockInfo, Decimal, Timestamp, Uint128, Uint256};
 use mesh_apis::vault_api::VaultApiHelper;
 
 use crate::points_alignment::PointsAlignment;
@@ -13,8 +13,10 @@ pub struct Config {
     pub rewards_denom: String,
     /// Vault contract address
     pub vault: VaultApiHelper,
-    /// Ubbounding period for claims in seconds
+    /// Unbounding period for claims in seconds
     pub unbonding_period: u64,
+    /// Max slash percentage (from InstantiateMsg, maybe later from the chain)
+    pub max_slashing: Decimal,
 }
 
 /// All single stake related information - entry per `(user, validator)` pair, including

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -13,7 +13,7 @@ pub struct Config {
     pub rewards_denom: String,
     /// Vault contract address
     pub vault: VaultApiHelper,
-    /// Unbounding period for claims in seconds
+    /// Unbonding period for claims in seconds
     pub unbonding_period: u64,
     /// Max slash percentage (from InstantiateMsg, maybe later from the chain)
     pub max_slashing: Decimal,

--- a/contracts/provider/native-staking-proxy/src/multitest.rs
+++ b/contracts/provider/native-staking-proxy/src/multitest.rs
@@ -68,6 +68,7 @@ fn setup<'app>(
         msg: to_binary(&mesh_native_staking::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
+            max_slashing: Decimal::percent(5),
         })
         .unwrap(),
         label: None,

--- a/contracts/provider/native-staking/src/error.rs
+++ b/contracts/provider/native-staking/src/error.rs
@@ -21,4 +21,7 @@ pub enum ContractError {
 
     #[error("Missing instantiate reply data")]
     NoInstantiateData {},
+
+    #[error("You cannot use a max slashing rate over 1.0 (100%)")]
+    InvalidMaxSlashing,
 }

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure_eq, from_slice, to_binary, Binary, Decimal, Response, SubMsg, WasmMsg};
+use cosmwasm_std::{ensure_eq, from_slice, to_binary, Binary, Response, SubMsg, WasmMsg};
 use cw_utils::must_pay;
 use sylvia::types::QueryCtx;
 use sylvia::{contract, types::ExecCtx};
@@ -6,12 +6,13 @@ use sylvia::{contract, types::ExecCtx};
 #[allow(unused_imports)]
 use mesh_apis::local_staking_api::{self, LocalStakingApi, MaxSlashResponse};
 
-use crate::contract::{NativeStakingContract, MAX_SLASH_PERCENTAGE, REPLY_ID_INSTANTIATE};
+use crate::contract::{NativeStakingContract, REPLY_ID_INSTANTIATE};
 use crate::error::ContractError;
 use crate::msg::StakeMsg;
 
 // FIXME: Move to sylvia contract macro
 use crate::contract::BoundQuerier;
+use crate::state::Config;
 
 #[contract]
 #[messages(local_staking_api as LocalStakingApi)]
@@ -79,9 +80,10 @@ impl LocalStakingApi for NativeStakingContract<'_> {
     /// Returns the maximum percentage that can be slashed
     /// TODO: Any way to query this from the chain? Or we just pass in InstantiateMsg?
     #[msg(query)]
-    fn max_slash(&self, _ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error> {
+    fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error> {
+        let Config { max_slashing, .. } = self.config.load(ctx.deps.storage)?;
         Ok(MaxSlashResponse {
-            max_slash: Decimal::percent(MAX_SLASH_PERCENTAGE),
+            max_slash: max_slashing,
         })
     }
 }

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -78,7 +78,6 @@ impl LocalStakingApi for NativeStakingContract<'_> {
     }
 
     /// Returns the maximum percentage that can be slashed
-    /// TODO: Any way to query this from the chain? Or we just pass in InstantiateMsg?
     #[msg(query)]
     fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error> {
         let Config { max_slashing, .. } = self.config.load(ctx.deps.storage)?;

--- a/contracts/provider/native-staking/src/state.rs
+++ b/contracts/provider/native-staking/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Decimal};
 
 #[cw_serde]
 pub struct Config {
@@ -11,4 +11,7 @@ pub struct Config {
 
     /// The address of the vault contract (where we get and return stake)
     pub vault: Addr,
+
+    /// Max slash percentage (from InstantiateMsg, maybe later from the chain)
+    pub max_slashing: Decimal,
 }


### PR DESCRIPTION
Closes #71 

Allows configuring max_slashing for native-staking and external-staking, making them more versatile and especially providing better test cases (when this is high, the total slashable becomes a factor).

Note this adds a new parameter to the InstantiateMsg of both of those contracts `max_slashable: Decimal`