### PR TITLE
List all rewards per user

### DIFF
--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -823,10 +823,11 @@ impl ExternalStakingContract<'_> {
                     .may_load(ctx.deps.storage, &validator)?
                     .unwrap_or_default();
                 let amount = Self::calculate_reward(stake, &distribution)?;
-                Ok::<_, ContractError>(ValidatorPendingReward {
+                Ok::<_, ContractError>(ValidatorPendingReward::new(
                     validator,
-                    amount: coin(amount.u128(), &config.rewards_denom),
-                })
+                    amount.u128(),
+                    &config.rewards_denom,
+                ))
             })
             .collect::<Result<_, _>>()?;
 

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -95,7 +95,7 @@ pub struct PendingRewards {
     pub amount: Coin,
 }
 
-/// Response for pending rewards query on one validator
+/// Response for pending rewards query on all validator
 #[cw_serde]
 pub struct AllPendingRewards {
     pub rewards: Vec<ValidatorPendingReward>,
@@ -103,12 +103,12 @@ pub struct AllPendingRewards {
 
 #[cw_serde]
 pub struct ValidatorPendingReward {
-    pub amount: Coin,
     pub validator: String,
+    pub amount: Coin,
 }
 
 impl ValidatorPendingReward {
-    pub fn new(amount: u128, denom: impl Into<String>, validator: impl Into<String>) -> Self {
+    pub fn new(validator: impl Into<String>, amount: u128, denom: impl Into<String>) -> Self {
         Self {
             amount: coin(amount, denom),
             validator: validator.into(),

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -89,10 +89,22 @@ pub struct UsersResponse {
     pub users: Vec<UserInfo>,
 }
 
-/// Response for penging rewards query
+/// Response for pending rewards query on one validator
 #[cw_serde]
 pub struct PendingRewards {
     pub amount: Coin,
+}
+
+/// Response for pending rewards query on one validator
+#[cw_serde]
+pub struct AllPendingRewards {
+    pub rewards: Vec<ValidatorPendingReward>,
+}
+
+#[cw_serde]
+pub struct ValidatorPendingReward {
+    pub amount: Coin,
+    pub validator: String,
 }
 
 pub type TxResponse = mesh_sync::Tx;

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, IbcChannel, Uint128};
+use cosmwasm_std::{coin, Coin, IbcChannel, Uint128};
 
 use crate::{error::ContractError, state::Config};
 
@@ -105,6 +105,15 @@ pub struct AllPendingRewards {
 pub struct ValidatorPendingReward {
     pub amount: Coin,
     pub validator: String,
+}
+
+impl ValidatorPendingReward {
+    pub fn new(amount: u128, denom: impl Into<String>, validator: impl Into<String>) -> Self {
+        Self {
+            amount: coin(amount, denom),
+            validator: validator.into(),
+        }
+    }
 }
 
 pub type TxResponse = mesh_sync::Tx;

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -787,15 +787,15 @@ fn distribution() {
         .all_pending_rewards(users[0].to_owned(), None, None)
         .unwrap();
     let expected = vec![
-        ValidatorPendingReward::new(20, STAR, validators[0]),
-        ValidatorPendingReward::new(30, STAR, validators[1]),
+        ValidatorPendingReward::new(validators[0], 20, STAR),
+        ValidatorPendingReward::new(validators[1], 30, STAR),
     ];
     assert_eq!(all_rewards.rewards, expected);
 
     let all_rewards = contract
         .all_pending_rewards(users[1].to_owned(), None, None)
         .unwrap();
-    let expected = vec![ValidatorPendingReward::new(30, STAR, validators[0])];
+    let expected = vec![ValidatorPendingReward::new(validators[0], 30, STAR)];
     assert_eq!(all_rewards.rewards, expected);
 
     // Distributed funds should be on the staking contract
@@ -1223,8 +1223,8 @@ fn distribution() {
         .all_pending_rewards(users[0].to_owned(), None, None)
         .unwrap();
     let expected = vec![
-        ValidatorPendingReward::new(6, STAR, validators[0]),
-        ValidatorPendingReward::new(2, STAR, validators[1]),
+        ValidatorPendingReward::new(validators[0], 6, STAR),
+        ValidatorPendingReward::new(validators[1], 2, STAR),
     ];
     assert_eq!(all_rewards.rewards, expected);
 
@@ -1232,8 +1232,8 @@ fn distribution() {
         .all_pending_rewards(users[1].to_owned(), None, None)
         .unwrap();
     let expected = vec![
-        ValidatorPendingReward::new(33, STAR, validators[0]),
-        ValidatorPendingReward::new(37, STAR, validators[1]),
+        ValidatorPendingReward::new(validators[0], 33, STAR),
+        ValidatorPendingReward::new(validators[1], 37, STAR),
     ];
     assert_eq!(all_rewards.rewards, expected);
 


### PR DESCRIPTION
Closes #47 

Helpful query to view all rewards a user has over all validators when cross-staking