### PR TITLE
Remove unneeded tx_id from Stake / Unstake Ack packets

### DIFF
--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -152,10 +152,10 @@ pub fn ibc_packet_receive(
         ProviderPacket::Stake {
             validator,
             stake,
-            tx_id,
+            tx_id: _,
         } => {
             let response = contract.stake(deps, validator, stake)?;
-            let ack = ack_success(&StakeAck { tx_id })?;
+            let ack = ack_success(&StakeAck {})?;
             IbcReceiveResponse::new()
                 .set_ack(ack)
                 .add_submessages(response.messages)
@@ -165,10 +165,10 @@ pub fn ibc_packet_receive(
         ProviderPacket::Unstake {
             validator,
             unstake,
-            tx_id,
+            tx_id: _,
         } => {
             let response = contract.unstake(deps, validator, unstake)?;
-            let ack = ack_success(&UnstakeAck { tx_id })?;
+            let ack = ack_success(&UnstakeAck {})?;
             IbcReceiveResponse::new()
                 .set_ack(ack)
                 .add_submessages(response.messages)

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -32,17 +32,11 @@ pub enum ProviderPacket {
 
 /// Ack sent for ProviderPacket::Stake
 #[cw_serde]
-pub struct StakeAck {
-    /// Return the value from the original packet
-    pub tx_id: u64,
-}
+pub struct StakeAck {}
 
 /// Ack sent for ProviderPacket::Unstake
 #[cw_serde]
-pub struct UnstakeAck {
-    /// Return the value from the original packet
-    pub tx_id: u64,
-}
+pub struct UnstakeAck {}
 
 /// These are messages sent from consumer -> provider
 /// ibc_packet_receive in external-staking must handle them all.


### PR DESCRIPTION
These are harmless. Just for clarity.