### PR TITLE
Prepare 0.4.0-alpha.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "external-staking"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -553,7 +553,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mesh-apis"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-bindings"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-converter"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-mocks"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-native-staking"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-native-staking-proxy"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-simple-price-feed"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-sync"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-vault"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-virtual-staking"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition       = "2021"
-version       = "0.3.0"
+version       = "0.4.0-alpha.1"
 license       = "MIT"
 repository    = "https://github.com/osmosis-labs/mesh-security"
 

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -17,9 +17,9 @@ use mesh_apis::ibc::{
 use crate::{contract::ConverterContract, error::ContractError};
 
 /// This is the maximum version of the Mesh Security protocol that we support
-const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "0.10.0";
+const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "0.11.0";
 /// This is the minimum version that we are compatible with
-const MIN_IBC_PROTOCOL_VERSION: &str = "0.10.0";
+const MIN_IBC_PROTOCOL_VERSION: &str = "0.11.0";
 
 // IBC specific state
 pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -18,9 +18,9 @@ use crate::error::ContractError;
 use crate::msg::AuthorizedEndpoint;
 
 /// This is the maximum version of the Mesh Security protocol that we support
-const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "0.10.0";
+const SUPPORTED_IBC_PROTOCOL_VERSION: &str = "0.11.0";
 /// This is the minimum version that we are compatible with
-const MIN_IBC_PROTOCOL_VERSION: &str = "0.10.0";
+const MIN_IBC_PROTOCOL_VERSION: &str = "0.11.0";
 
 // IBC specific state
 pub const AUTH_ENDPOINT: Item<AuthorizedEndpoint> = Item::new("auth_endpoint");


### PR DESCRIPTION
Merge and tag after #86 

- Bump cargo version to 0.4.0-alpha.1
- Bump ibc protocol version to 0.11