### PR TITLE
F/value range add sub helpers

### DIFF
--- a/packages/sync/src/range.rs
+++ b/packages/sync/src/range.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::{Debug, Formatter},
     iter::Sum,
     ops::{Add, Mul, Sub},
 };
@@ -266,6 +267,16 @@ where
     #[inline]
     fn assert_valid_range(&self) {
         assert!(self.low <= self.high);
+    }
+}
+
+// Use Debug output for Display as well
+impl<T> std::fmt::Display for ValueRange<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 

--- a/packages/sync/src/txs.rs
+++ b/packages/sync/src/txs.rs
@@ -59,7 +59,7 @@ impl Tx {
     }
 }
 
-// Use Debug output for display as well (simplify the previous hand-coding of that)
+// Use Debug output for Display as well
 impl std::fmt::Display for Tx {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)


### PR DESCRIPTION
Add a couple of helpers to `ValueRange` for non-transactional addition and subtraction.

~~Names clash sometimes (but not always) with the `std::ops::Add` impl. That's unfortunate, but I couldn't think of better names. In any case, clashing can be avoided by using the fully qualified syntax for addition~~. (solved it by replacing the `Add` impl by a helper function)

Also adds a stock `Display` impl.