### PR TITLE
Ownership check on simple price feeder

### DIFF
--- a/contracts/consumer/simple-price-feed/src/contract.rs
+++ b/contracts/consumer/simple-price-feed/src/contract.rs
@@ -62,6 +62,12 @@ impl SimplePriceFeedContract<'_> {
         nonpayable(&ctx.info)?;
 
         let mut config = self.config.load(ctx.deps.storage)?;
+
+        // Only allow owner to call this
+        if ctx.info.sender != config.owner {
+            return Err(ContractError::Unauthorized {});
+        }
+
         config.native_per_foreign = native_per_foreign;
         self.config.save(ctx.deps.storage, &config)?;
         Ok(Response::new())

--- a/contracts/consumer/simple-price-feed/src/contract.rs
+++ b/contracts/consumer/simple-price-feed/src/contract.rs
@@ -64,9 +64,11 @@ impl SimplePriceFeedContract<'_> {
         let mut config = self.config.load(ctx.deps.storage)?;
 
         // Only allow owner to call this
-        if ctx.info.sender != config.owner {
-            return Err(ContractError::Unauthorized {});
-        }
+        ensure_eq!(
+            ctx.info.sender,
+            config.owner,
+            ContractError::Unauthorized {}
+        );
 
         config.native_per_foreign = native_per_foreign;
         self.config.save(ctx.deps.storage, &config)?;


### PR DESCRIPTION
- Adds a missing ownership check on `simple-price-feeder`
- Updates `Cargo.lock` file