### PR TITLE
feat: Move ibc workaround methods in ExternalStaking to interface

### DIFF
--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -10,7 +10,6 @@ use sylvia::contract;
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
 
 use mesh_apis::cross_staking_api::{self};
-use mesh_apis::ibc::AddValidator;
 use mesh_apis::ibc::ProviderPacket;
 use mesh_apis::vault_api::VaultApiHelper;
 use mesh_sync::Tx;
@@ -55,6 +54,7 @@ pub struct ExternalStakingContract<'a> {
 #[contract]
 #[error(ContractError)]
 #[messages(cross_staking_api as CrossStakingApi)]
+#[messages(crate::test_methods as TestMethods)]
 impl ExternalStakingContract<'_> {
     pub const fn new() -> Self {
         Self {
@@ -221,70 +221,6 @@ impl ExternalStakingContract<'_> {
         let cfg = self.config.load(deps.storage)?;
         let msg = cfg.vault.rollback_tx(tx_id)?;
         Ok(msg)
-    }
-
-    /// Commits a pending stake.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_commit_stake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
-        #[cfg(any(feature = "mt", test))]
-        {
-            let msg = self.commit_stake(ctx.deps, tx_id)?;
-            Ok(Response::new().add_message(msg))
-        }
-        #[cfg(not(any(feature = "mt", test)))]
-        {
-            let _ = (ctx, tx_id);
-            Err(ContractError::Unauthorized {})
-        }
-    }
-
-    /// Rollbacks a pending stake.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_rollback_stake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
-        #[cfg(any(test, feature = "mt"))]
-        {
-            let msg = self.rollback_stake(ctx.deps, tx_id)?;
-            Ok(Response::new().add_message(msg))
-        }
-        #[cfg(not(any(test, feature = "mt")))]
-        {
-            let _ = (ctx, tx_id);
-            Err(ContractError::Unauthorized {})
-        }
-    }
-
-    /// Updates the active validator set.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_set_active_validator(
-        &self,
-        ctx: ExecCtx,
-        validator: AddValidator,
-    ) -> Result<Response, ContractError> {
-        #[cfg(any(feature = "mt", test))]
-        {
-            let AddValidator {
-                valoper,
-                pub_key,
-                start_height,
-                start_time,
-            } = validator;
-            let update = crate::crdt::ValUpdate {
-                pub_key,
-                start_height,
-                start_time,
-            };
-            self.val_set
-                .add_validator(ctx.deps.storage, &valoper, update)?;
-            Ok(Response::new())
-        }
-        #[cfg(not(any(feature = "mt", test)))]
-        {
-            let _ = (ctx, validator);
-            Err(ContractError::Unauthorized {})
-        }
     }
 
     /// Schedules tokens for release, adding them to the pending unbonds. After the unbonding period
@@ -472,38 +408,6 @@ impl ExternalStakingContract<'_> {
         Ok(())
     }
 
-    /// Commits a pending unstake.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_commit_unstake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
-        #[cfg(any(test, feature = "mt"))]
-        {
-            self.commit_unstake(ctx.deps, ctx.env, tx_id)?;
-            Ok(Response::new())
-        }
-        #[cfg(not(any(test, feature = "mt")))]
-        {
-            let _ = (ctx, tx_id);
-            Err(ContractError::Unauthorized {})
-        }
-    }
-
-    /// Rollbacks a pending unstake.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_rollback_unstake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
-        #[cfg(any(test, feature = "mt"))]
-        {
-            self.rollback_unstake(ctx.deps, tx_id)?;
-            Ok(Response::new())
-        }
-        #[cfg(not(any(test, feature = "mt")))]
-        {
-            let _ = (ctx, tx_id);
-            Err(ContractError::Unauthorized {})
-        }
-    }
-
     /// Withdraws all of their released tokens to the calling user.
     ///
     /// Tokens to be claimed have to be unbond before by calling the `unbond` message, and
@@ -553,27 +457,6 @@ impl ExternalStakingContract<'_> {
         }
 
         Ok(resp)
-    }
-
-    /// Distribute rewards.
-    /// Method used for tests only.
-    #[msg(exec)]
-    pub fn test_distribute_rewards(
-        &self,
-        ctx: ExecCtx,
-        validator: String,
-        rewards: Coin,
-    ) -> Result<Response, ContractError> {
-        #[cfg(any(test, feature = "mt"))]
-        {
-            let event = self.distribute_rewards(ctx.deps, validator, rewards)?;
-            Ok(Response::new().add_event(event))
-        }
-        #[cfg(not(any(test, feature = "mt")))]
-        {
-            let _ = (ctx, validator, rewards);
-            Err(ContractError::Unauthorized)
-        }
     }
 
     /// Distributes reward among users staking via particular validator. Distribution is performed
@@ -689,46 +572,6 @@ impl ExternalStakingContract<'_> {
         }
 
         Ok(resp)
-    }
-
-    /// Commits a withdraw rewards transaction.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_commit_withdraw_rewards(
-        &self,
-        ctx: ExecCtx,
-        tx_id: u64,
-    ) -> Result<Response, ContractError> {
-        #[cfg(any(test, feature = "mt"))]
-        {
-            self.commit_withdraw_rewards(ctx.deps, tx_id)?;
-            Ok(Response::new())
-        }
-        #[cfg(not(any(test, feature = "mt")))]
-        {
-            let _ = (ctx, tx_id);
-            Err(ContractError::Unauthorized {})
-        }
-    }
-
-    /// Rollbacks a withdraw rewards transaction.
-    /// Method used for tests only.
-    #[msg(exec)]
-    fn test_rollback_withdraw_rewards(
-        &self,
-        ctx: ExecCtx,
-        tx_id: u64,
-    ) -> Result<Response, ContractError> {
-        #[cfg(any(test, feature = "mt"))]
-        {
-            self.rollback_withdraw_rewards(ctx.deps, tx_id)?;
-            Ok(Response::new())
-        }
-        #[cfg(not(any(test, feature = "mt")))]
-        {
-            let _ = (ctx, tx_id);
-            Err(ContractError::Unauthorized {})
-        }
     }
 
     /// In test code, this is called from `test_rollback_withdraw_rewards`.

--- a/contracts/provider/external-staking/src/lib.rs
+++ b/contracts/provider/external-staking/src/lib.rs
@@ -7,3 +7,5 @@ pub mod msg;
 mod multitest;
 mod points_alignment;
 pub mod state;
+pub mod test_methods;
+pub mod test_methods_impl;

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -18,6 +18,7 @@ use crate::contract::multitest_utils::{CodeId, ExternalStakingContractProxy};
 use crate::error::ContractError;
 use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo, ValidatorPendingRewards};
 use crate::state::Stake;
+use crate::test_methods_impl::test_utils::TestMethods;
 
 const OSMO: &str = "osmo";
 const STAR: &str = "star";
@@ -118,6 +119,7 @@ fn staking() {
     for val in validators {
         let activate = AddValidator::mock(val);
         contract
+            .test_methods_proxy()
             .test_set_active_validator(activate)
             .call("test")
             .unwrap();
@@ -174,6 +176,7 @@ fn staking() {
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&contract).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     contract
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -191,6 +194,7 @@ fn staking() {
         .unwrap();
 
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -207,6 +211,7 @@ fn staking() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -223,6 +228,7 @@ fn staking() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -239,6 +245,7 @@ fn staking() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -336,6 +343,7 @@ fn unstaking() {
     for val in validators {
         let activate = AddValidator::mock(val);
         contract
+            .test_methods_proxy()
             .test_set_active_validator(activate)
             .call("test")
             .unwrap();
@@ -373,6 +381,7 @@ fn unstaking() {
     // This should be through `IbcPacketAckMsg`
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -390,6 +399,7 @@ fn unstaking() {
         .unwrap();
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -407,6 +417,7 @@ fn unstaking() {
         .unwrap();
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -419,6 +430,7 @@ fn unstaking() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -428,6 +440,7 @@ fn unstaking() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -437,6 +450,7 @@ fn unstaking() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -536,6 +550,7 @@ fn unstaking() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -545,6 +560,7 @@ fn unstaking() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -661,6 +677,7 @@ fn distribution() {
     for val in validators {
         let activate = AddValidator::mock(val);
         contract
+            .test_methods_proxy()
             .test_set_active_validator(activate)
             .call("test")
             .unwrap();
@@ -704,6 +721,7 @@ fn distribution() {
     // This should be through `IbcPacketAckMsg`
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -720,6 +738,7 @@ fn distribution() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -736,6 +755,7 @@ fn distribution() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -744,6 +764,7 @@ fn distribution() {
     // 20 tokens for users[0]
     // 30 tokens for users[1]
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(50, STAR))
         .call(owner)
         .unwrap();
@@ -751,6 +772,7 @@ fn distribution() {
     // Only users[0] stakes on validators[1]
     // 30 tokens for users[0]
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[1].to_owned(), coin(30, STAR))
         .call(owner)
         .unwrap();
@@ -801,12 +823,14 @@ fn distribution() {
     // 42 tokens for users[1]
     // 1 token is not distributed
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(71, STAR))
         .call(owner)
         .unwrap();
 
     // Distribution in invalid coin should fail
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[1].to_owned(), coin(100, OSMO))
         .call(owner)
         .unwrap_err();
@@ -844,6 +868,7 @@ fn distribution() {
 
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -854,6 +879,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -864,6 +890,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[1])
         .unwrap();
@@ -930,6 +957,7 @@ fn distribution() {
     //
     // The additional 1 token is leftover after previous allocation
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(9, STAR))
         .call(owner)
         .unwrap();
@@ -952,6 +980,7 @@ fn distribution() {
     // 4 on users[0] (+ ~0.4)
     // 6 on users[1] (+ ~0.6)
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
@@ -960,6 +989,7 @@ fn distribution() {
     //
     // 11 on users[0]
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[1].to_owned(), coin(11, STAR))
         .call(owner)
         .unwrap();
@@ -974,6 +1004,7 @@ fn distribution() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -996,6 +1027,7 @@ fn distribution() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -1029,6 +1061,7 @@ fn distribution() {
     // 10 on users[0] (~0.4 still not distributed)
     // 10 on users[1] (~0.6 still not distributed)
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(20, STAR))
         .call(owner)
         .unwrap();
@@ -1037,6 +1070,7 @@ fn distribution() {
     // 10 on users[1]
     // 30 on users[2]
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[1].to_owned(), coin(40, STAR))
         .call(owner)
         .unwrap();
@@ -1072,6 +1106,7 @@ fn distribution() {
     // 3 for users[1] (+ ~0.5 from this distribution + ~0.6 accumulated -> ~1.1 tokens, we give one
     //   back leaving ~0.1 accumulated)
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(5, STAR))
         .call(owner)
         .unwrap();
@@ -1104,6 +1139,7 @@ fn distribution() {
         .call(users[0])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -1113,6 +1149,7 @@ fn distribution() {
         .call(users[1])
         .unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
         .call("test")
         .unwrap();
@@ -1122,6 +1159,7 @@ fn distribution() {
     // 7 + 1 = 8 to users[0] (~0.9 accumulated + ~0.2 = ~1.1 leftover, 1.0 payed back, ~0.1 accumulated)
     // 4 to users[0] (~0.1 accumulated + ~0.8 -> leaving at ~0.9)
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(12, STAR))
         .call(owner)
         .unwrap();
@@ -1145,6 +1183,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -1155,6 +1194,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -1166,6 +1206,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_rollback_withdraw_rewards(tx_id)
         .call(users[1])
         .unwrap();
@@ -1222,11 +1263,13 @@ fn distribution() {
     // 2 tokens to users[0] via validators[1] (~0.5 leftover)
     // 7 tokens to users[1] via validators[1] (~0.5 lefover)
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[0].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
 
     contract
+        .test_methods_proxy()
         .test_distribute_rewards(validators[1].to_owned(), coin(10, STAR))
         .call(owner)
         .unwrap();
@@ -1281,6 +1324,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -1291,6 +1335,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -1301,6 +1346,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();
@@ -1311,6 +1357,7 @@ fn distribution() {
         .unwrap();
     let tx_id = get_last_external_staking_pending_tx_id(&contract).unwrap();
     contract
+        .test_methods_proxy()
         .test_commit_withdraw_rewards(tx_id)
         .call(users[0])
         .unwrap();

--- a/contracts/provider/external-staking/src/test_methods.rs
+++ b/contracts/provider/external-staking/src/test_methods.rs
@@ -1,0 +1,60 @@
+use cosmwasm_std::{Coin, Response, StdError};
+use mesh_apis::ibc::AddValidator;
+use sylvia::interface;
+use sylvia::types::ExecCtx;
+
+/// Interface to work around lack of support for IBC in `cw-multi-test`
+/// This interface is for test usage only
+#[interface]
+pub trait TestMethods {
+    type Error: From<StdError>;
+
+    /// Commits a pending stake.
+    #[msg(exec)]
+    fn test_commit_stake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error>;
+
+    /// Rollbacks a pending stake.
+    #[msg(exec)]
+    fn test_rollback_stake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error>;
+
+    /// Updates the active validator set.
+    #[msg(exec)]
+    fn test_set_active_validator(
+        &self,
+        ctx: ExecCtx,
+        validator: AddValidator,
+    ) -> Result<Response, Self::Error>;
+
+    /// Commits a pending unstake.
+    #[msg(exec)]
+    fn test_commit_unstake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error>;
+
+    /// Rollbacks a pending unstake.
+    #[msg(exec)]
+    fn test_rollback_unstake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, Self::Error>;
+
+    /// Distribute rewards.
+    #[msg(exec)]
+    fn test_distribute_rewards(
+        &self,
+        ctx: ExecCtx,
+        validator: String,
+        rewards: Coin,
+    ) -> Result<Response, Self::Error>;
+
+    /// Commits a withdraw rewards transaction.
+    #[msg(exec)]
+    fn test_commit_withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        tx_id: u64,
+    ) -> Result<Response, Self::Error>;
+
+    /// Rollbacks a withdraw rewards transaction.
+    #[msg(exec)]
+    fn test_rollback_withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        tx_id: u64,
+    ) -> Result<Response, Self::Error>;
+}

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -1,0 +1,164 @@
+use crate::contract::ExternalStakingContract;
+use crate::error::ContractError;
+use crate::test_methods::TestMethods;
+
+use cosmwasm_std::{Coin, Response};
+use mesh_apis::ibc::AddValidator;
+use sylvia::contract;
+use sylvia::types::ExecCtx;
+
+/// These methods are for test usage only
+#[contract(module=crate::contract)]
+#[messages(crate::test_methods as TestMethods)]
+impl TestMethods for ExternalStakingContract<'_> {
+    type Error = ContractError;
+
+    /// Commits a pending stake.
+    #[msg(exec)]
+    fn test_commit_stake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
+        #[cfg(any(feature = "mt", test))]
+        {
+            let msg = self.commit_stake(ctx.deps, tx_id)?;
+            Ok(Response::new().add_message(msg))
+        }
+        #[cfg(not(any(feature = "mt", test)))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    /// Rollbacks a pending stake.
+    #[msg(exec)]
+    fn test_rollback_stake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            let msg = self.rollback_stake(ctx.deps, tx_id)?;
+            Ok(Response::new().add_message(msg))
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    /// Updates the active validator set.
+    #[msg(exec)]
+    fn test_set_active_validator(
+        &self,
+        ctx: ExecCtx,
+        validator: AddValidator,
+    ) -> Result<Response, ContractError> {
+        #[cfg(any(feature = "mt", test))]
+        {
+            let AddValidator {
+                valoper,
+                pub_key,
+                start_height,
+                start_time,
+            } = validator;
+            let update = crate::crdt::ValUpdate {
+                pub_key,
+                start_height,
+                start_time,
+            };
+            self.val_set
+                .add_validator(ctx.deps.storage, &valoper, update)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(any(feature = "mt", test)))]
+        {
+            let _ = (ctx, validator);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    /// Commits a pending unstake.
+    #[msg(exec)]
+    fn test_commit_unstake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            self.commit_unstake(ctx.deps, ctx.env, tx_id)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    /// Rollbacks a pending unstake.
+    #[msg(exec)]
+    fn test_rollback_unstake(&self, ctx: ExecCtx, tx_id: u64) -> Result<Response, ContractError> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            self.rollback_unstake(ctx.deps, tx_id)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    /// Distribute rewards.
+    #[msg(exec)]
+    fn test_distribute_rewards(
+        &self,
+        ctx: ExecCtx,
+        validator: String,
+        rewards: Coin,
+    ) -> Result<Response, ContractError> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            let event = self.distribute_rewards(ctx.deps, validator, rewards)?;
+            Ok(Response::new().add_event(event))
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, validator, rewards);
+            Err(ContractError::Unauthorized)
+        }
+    }
+
+    /// Commits a withdraw rewards transaction.
+    #[msg(exec)]
+    fn test_commit_withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        tx_id: u64,
+    ) -> Result<Response, ContractError> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            self.commit_withdraw_rewards(ctx.deps, tx_id)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+
+    /// Rollbacks a withdraw rewards transaction.
+    #[msg(exec)]
+    fn test_rollback_withdraw_rewards(
+        &self,
+        ctx: ExecCtx,
+        tx_id: u64,
+    ) -> Result<Response, ContractError> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            self.rollback_withdraw_rewards(ctx.deps, tx_id)?;
+            Ok(Response::new())
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, tx_id);
+            Err(ContractError::Unauthorized {})
+        }
+    }
+}

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -5,6 +5,7 @@ use cw_multi_test::App as MtApp;
 use mesh_apis::ibc::AddValidator;
 use mesh_external_staking::contract::multitest_utils::ExternalStakingContractProxy;
 use mesh_external_staking::msg::{AuthorizedEndpoint, ReceiveVirtualStake};
+use mesh_external_staking::test_methods_impl::test_utils::TestMethods;
 use mesh_sync::Tx::InFlightStaking;
 use mesh_sync::{Tx, ValueRange};
 use sylvia::multitest::App;
@@ -536,6 +537,7 @@ fn stake_cross() {
 
     let activate = AddValidator::mock(validator);
     cross_staking
+        .test_methods_proxy()
         .test_set_active_validator(activate)
         .call("test")
         .unwrap();
@@ -602,6 +604,7 @@ fn stake_cross() {
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&cross_staking).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -666,6 +669,7 @@ fn stake_cross() {
     let last_external_staking_tx = get_last_external_staking_pending_tx_id(&cross_staking).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -779,6 +783,7 @@ fn stake_cross() {
     skip_time(&app, unbond_period);
     let tx_id = get_last_external_staking_pending_tx_id(&cross_staking).unwrap();
     cross_staking
+        .test_methods_proxy()
         .test_commit_unstake(tx_id)
         .call("test")
         .unwrap();
@@ -845,6 +850,7 @@ fn stake_cross() {
 
     let tx_id = get_last_external_staking_pending_tx_id(&cross_staking).unwrap();
     cross_staking
+        .test_methods_proxy()
         .test_commit_unstake(tx_id)
         .call("test")
         .unwrap();
@@ -949,6 +955,7 @@ fn stake_cross_txs() {
 
     let activate = AddValidator::mock(validator);
     cross_staking
+        .test_methods_proxy()
         .test_set_active_validator(activate)
         .call("test")
         .unwrap();
@@ -1241,6 +1248,7 @@ fn stake_cross_rollback_tx() {
 
     let activate = AddValidator::mock(validator);
     cross_staking
+        .test_methods_proxy()
         .test_set_active_validator(activate)
         .call("test")
         .unwrap();
@@ -1392,11 +1400,13 @@ fn multiple_stakes() {
 
     let activate = AddValidator::mock(validator);
     cross_staking1
+        .test_methods_proxy()
         .test_set_active_validator(activate.clone())
         .call("test")
         .unwrap();
 
     cross_staking2
+        .test_methods_proxy()
         .test_set_active_validator(activate)
         .call("test")
         .unwrap();
@@ -1438,6 +1448,7 @@ fn multiple_stakes() {
         get_last_external_staking_pending_tx_id(&cross_staking1).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking1
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -1460,6 +1471,7 @@ fn multiple_stakes() {
         get_last_external_staking_pending_tx_id(&cross_staking2).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking2
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -1515,6 +1527,7 @@ fn multiple_stakes() {
         get_last_external_staking_pending_tx_id(&cross_staking1).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking1
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -1537,6 +1550,7 @@ fn multiple_stakes() {
         get_last_external_staking_pending_tx_id(&cross_staking2).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking2
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();
@@ -1590,6 +1604,7 @@ fn multiple_stakes() {
         get_last_external_staking_pending_tx_id(&cross_staking1).unwrap();
     println!("last_external_staking_tx: {:?}", last_external_staking_tx);
     cross_staking1
+        .test_methods_proxy()
         .test_commit_stake(last_external_staking_tx)
         .call("test")
         .unwrap();


### PR DESCRIPTION
Example usage of interface to keep test workaround methods out of contract