### PR TITLE
bug: add missing import for macro

### DIFF
--- a/contracts/consumer/simple-price-feed/src/contract.rs
+++ b/contracts/consumer/simple-price-feed/src/contract.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Decimal, Response};
+use cosmwasm_std::{ensure_eq, Decimal, Response};
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
 use cw_utils::nonpayable;


### PR DESCRIPTION
## Overview
When running `cargo wasm`, got error of missing import. Seems to be true in the CI as well. 
Add import for macro.