### PR TITLE
Add Consumer validator tombstoning routing / msgs

### DIFF
--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -223,7 +223,7 @@ fn valset_update_works() {
     );
 
     // Send a valset update
-    let new_validators = vec![
+    let add_validators = vec![
         Validator {
             address: "validator1".to_string(),
             commission: Default::default(),
@@ -237,17 +237,23 @@ fn valset_update_works() {
             max_change_rate: Default::default(),
         },
     ];
+    let rem_validators = vec![Validator {
+        address: "validator3".to_string(),
+        commission: Default::default(),
+        max_commission: Default::default(),
+        max_change_rate: Default::default(),
+    }];
 
     // Check that only the virtual staking contract can call this handler
     let res = converter
         .converter_api_proxy()
-        .valset_update(vec![])
+        .valset_update(vec![], vec![])
         .call(owner);
     assert_eq!(res.unwrap_err(), Unauthorized {});
 
     let res = converter
         .converter_api_proxy()
-        .valset_update(new_validators)
+        .valset_update(add_validators, rem_validators)
         .call(virtual_staking.contract_addr.as_ref());
 
     // This fails because of lack of IBC support in mt now.

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -144,6 +144,7 @@ impl VirtualStakingContract<'_> {
         deps: DepsMut<VirtualStakeCustomQuery>,
         additions: &[Validator],
         removals: &[Validator],
+        tombstones: &[Validator],
     ) -> Result<Response<VirtualStakeCustomMsg>, ContractError> {
         // TODO: Store/process removals (and additions) locally, so that they are filtered out from
         // the `bonded` list
@@ -153,6 +154,7 @@ impl VirtualStakingContract<'_> {
         let cfg = self.config.load(deps.storage)?;
         let msg = converter_api::ExecMsg::ValsetUpdate {
             additions: additions.to_vec(),
+            tombstones: tombstones.to_vec(),
         };
         let msg = WasmMsg::Execute {
             contract_addr: cfg.converter.to_string(),
@@ -357,6 +359,12 @@ pub fn sudo(
         SudoMsg::ValsetUpdate {
             additions,
             removals,
-        } => VirtualStakingContract::new().handle_valset_update(deps, &additions, &removals),
+            tombstones,
+        } => VirtualStakingContract::new().handle_valset_update(
+            deps,
+            &additions,
+            &removals,
+            &tombstones,
+        ),
     }
 }

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -150,7 +150,7 @@ impl VirtualStakingContract<'_> {
         // the `bonded` list
         let _ = removals;
 
-        // Send additions to the converter. Removals are considered non-permanent and ignored
+        // Send additions and tombstones to the Converter. Removals are non-permanent and ignored
         let cfg = self.config.load(deps.storage)?;
         let msg = converter_api::ExecMsg::ValsetUpdate {
             additions: additions.to_vec(),

--- a/contracts/consumer/virtual-staking/src/multitest.rs
+++ b/contracts/consumer/virtual-staking/src/multitest.rs
@@ -153,9 +153,16 @@ fn valset_update_sudo() {
         max_commission: Decimal::percent(20),
         max_change_rate: Default::default(),
     }];
+    let tombs = vec![Validator {
+        address: "cosmosval3".to_string(),
+        commission: Decimal::percent(3),
+        max_commission: Decimal::percent(30),
+        max_change_rate: Default::default(),
+    }];
     let msg = SudoMsg::ValsetUpdate {
         additions: adds,
         removals: rems,
+        tombstones: tombs,
     };
 
     let res = app

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -27,8 +27,11 @@ pub trait ConverterApi {
         payments: Vec<RewardInfo>,
     ) -> Result<Response, Self::Error>;
 
-    /// Valset updates. Only additions are accepted, as removals (leaving the active validator set)
-    /// are non-permanent and ignored (CRDTs only support permanent removals).
+    /// Valset updates.
+    ///
+    /// Only additions and permanent removals are accepted, as removals (leaving the active
+    /// validator set) are non-permanent and ignored on the Provider (CRDTs only support permanent
+    /// removals).
     ///
     /// If a validator that already exists in the list is re-sent for addition, its pubkey
     /// will be updated.
@@ -38,6 +41,7 @@ pub trait ConverterApi {
         &self,
         ctx: ExecCtx,
         additions: Vec<Validator>,
+        tombstones: Vec<Validator>,
     ) -> Result<Response, Self::Error>;
 }
 

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -18,7 +18,7 @@ pub trait VirtualStakingApi {
 
     /// Requests to unbond tokens from a validator. This will be actually handled at the next epoch.
     /// If the virtual staking module is over the max cap, it will trigger a rebalance in addition to unbond.
-    /// If the virtual staking contract doesn't have at least amont tokens staked to the given validator, this will return an error.
+    /// If the virtual staking contract doesn't have at least amount tokens staked to the given validator, this will return an error.
     #[msg(exec)]
     fn unbond(
         &self,
@@ -37,10 +37,12 @@ pub enum SudoMsg {
     /// It should also withdraw all pending rewards here, and send them to the converter contract.
     Rebalance {},
     /// SudoMsg::ValsetUpdate{} should be called every time there's a validator set update: addition
-    /// of a new validator to the active validator set, or removal of a validator from the
-    /// active validator set.
+    /// of a new validator to the active validator set, removal of a validator from the
+    /// active validator set, or permanent removal (i.e. tombstoning) of a validator from the active
+    /// validator set.
     ValsetUpdate {
         additions: Vec<Validator>,
         removals: Vec<Validator>,
+        tombstones: Vec<Validator>,
     },
 }


### PR DESCRIPTION
Closes part of #118.

Doing it in a different PR as this only affects the Consumer side, and it is mostly compatible with the current impl.