### PR TITLE
F/validator historical query

### DIFF
--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -271,7 +271,13 @@ mod tests {
         crdt.add_validator(
             &mut storage,
             "alice",
-            mock_update_pubkey("alice_pubkey_2", 201),
+            mock_update_pubkey("alice_pubkey_2", 202),
+        )
+        .unwrap();
+        crdt.add_validator(
+            &mut storage,
+            "alice",
+            mock_update_pubkey("alice_pubkey_3", 203),
         )
         .unwrap();
 
@@ -288,15 +294,15 @@ mod tests {
             })
         );
 
-        // query at update height
+        // query at 2nd update height
         let alice = crdt
-            .active_validator_at_height(&storage, "alice", 201)
+            .active_validator_at_height(&storage, "alice", 202)
             .unwrap();
         assert_eq!(
             alice,
             Some(ValUpdate {
                 pub_key: "alice_pubkey_2".to_string(),
-                start_height: 201,
+                start_height: 202,
                 start_time: 1687339542,
             })
         );
@@ -308,8 +314,8 @@ mod tests {
         assert_eq!(
             alice,
             Some(ValUpdate {
-                pub_key: "alice_pubkey_2".to_string(),
-                start_height: 201,
+                pub_key: "alice_pubkey_3".to_string(),
+                start_height: 203,
                 start_time: 1687339542,
             })
         );

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -28,6 +28,10 @@ impl ActiveState {
         self.0.sort_by(|a, b| b.start_height.cmp(&a.start_height));
         self.0.dedup();
     }
+
+    pub fn query_at_height(&self, height: u64) -> Option<&ValUpdate> {
+        self.0.iter().find(|u| u.start_height <= height)
+    }
 }
 
 #[cw_serde]


### PR DESCRIPTION
Closes #119.

Turns out only this is required to have historical validator queries (if we don't mind losing history when validator is tombstoned).

This can be improved by doing a [lower bound](https://cplusplus.com/reference/algorithm/lower_bound/) binary search for a given height. Given that queries will be mostly from recent heights, and that the list will be generally short, and can even be pruned relatively easily, I don't think it's worth it. In fact, linear search will probably be more efficient in practice.