### PR TITLE
Batch rewards distribution

### DIFF
--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -326,7 +326,7 @@ impl ConverterApi for ConverterContract<'_> {
             }))
             .add_message(make_ibc_packet(
                 &mut ctx,
-                ConsumerPacket::DistributeRewards {
+                ConsumerPacket::DistributeBatch {
                     rewards: payments,
                     denom,
                 },

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    ensure_eq, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, IbcMsg,
-    Reply, Response, SubMsg, SubMsgResponse, Uint128, Validator, WasmMsg,
+    ensure_eq, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, Reply,
+    Response, SubMsg, SubMsgResponse, Uint128, Validator, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
@@ -14,9 +14,7 @@ use mesh_apis::price_feed_api;
 use mesh_apis::virtual_staking_api;
 
 use crate::error::ContractError;
-use crate::ibc::{
-    add_validators_msg, packet_timeout_rewards, tombstone_validators_msg, IBC_CHANNEL,
-};
+use crate::ibc::{add_validators_msg, make_ibc_packet, tombstone_validators_msg, IBC_CHANNEL};
 use crate::msg::ConfigResponse;
 use crate::state::Config;
 
@@ -379,13 +377,4 @@ impl ConverterApi for ConverterContract<'_> {
 
         Ok(resp)
     }
-}
-
-fn make_ibc_packet(ctx: &mut ExecCtx, packet: ConsumerPacket) -> Result<IbcMsg, ContractError> {
-    let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
-    Ok(IbcMsg::SendPacket {
-        channel_id: channel.endpoint.channel_id,
-        data: to_binary(&packet)?,
-        timeout: packet_timeout_rewards(&ctx.env),
-    })
 }

--- a/contracts/consumer/converter/src/error.rs
+++ b/contracts/consumer/converter/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::StdError;
+use cosmwasm_std::{StdError, Uint128};
 use cw_utils::{ParseReplyError, PaymentError};
 use mesh_apis::ibc::VersionError;
 use thiserror::Error;
@@ -37,4 +37,7 @@ pub enum ContractError {
 
     #[error("Invalid denom: {0}")]
     InvalidDenom(String),
+
+    #[error("Sum of rewards ({sum}) doesn't match funds sent ({sent})")]
+    DistributeRewardsInvalidAmount { sum: Uint128, sent: Uint128 },
 }

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -13,6 +13,7 @@ use mesh_apis::ibc::{
     ack_success, validate_channel_order, AckWrapper, AddValidator, ConsumerPacket, ProtocolVersion,
     ProviderPacket, StakeAck, TransferRewardsAck, UnstakeAck, PROTOCOL_NAME,
 };
+use sylvia::types::ExecCtx;
 
 use crate::{contract::ConverterContract, error::ContractError};
 
@@ -260,4 +261,16 @@ pub fn ibc_packet_timeout(
         timeout: packet_timeout_validator(&env),
     };
     Ok(IbcBasicResponse::new().add_message(msg))
+}
+
+pub(crate) fn make_ibc_packet(
+    ctx: &mut ExecCtx,
+    packet: ConsumerPacket,
+) -> Result<IbcMsg, ContractError> {
+    let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
+    Ok(IbcMsg::SendPacket {
+        channel_id: channel.endpoint.channel_id,
+        data: to_binary(&packet)?,
+        timeout: packet_timeout_rewards(&ctx.env),
+    })
 }

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -275,17 +275,12 @@ fn distribute_rewards_invalid_amount_is_rejected() {
     let discount = Decimal::percent(10); // 1 OSMO worth of JUNO should give 0.9 OSMO of stake
     let native_per_foreign = Decimal::percent(40); // 1 JUNO is worth 0.4 OSMO
 
-    let app = App::new(MtApp::new(|router, _, storage| {
-        router
-            .bank
-            .init_balance(storage, &Addr::unchecked(owner), coins(99999, "TOKEN"))
-            .unwrap();
-    }));
+    let app = App::default();
 
     let SetupResponse {
         price_feed: _,
         converter,
-        ..
+        virtual_staking,
     } = setup(
         &app,
         SetupArgs {
@@ -295,6 +290,17 @@ fn distribute_rewards_invalid_amount_is_rejected() {
             native_per_foreign,
         },
     );
+
+    app.app_mut().init_modules(|router, _, storage| {
+        router
+            .bank
+            .init_balance(
+                storage,
+                &virtual_staking.contract_addr,
+                coins(99999, "TOKEN"),
+            )
+            .unwrap();
+    });
 
     let err = converter
         .converter_api_proxy()
@@ -309,7 +315,7 @@ fn distribute_rewards_invalid_amount_is_rejected() {
             },
         ])
         .with_funds(&[coin(80, "TOKEN")])
-        .call(owner)
+        .call(virtual_staking.contract_addr.as_str())
         .unwrap_err();
 
     assert_eq!(
@@ -333,7 +339,7 @@ fn distribute_rewards_invalid_amount_is_rejected() {
             },
         ])
         .with_funds(&[coin(90, "TOKEN")])
-        .call(owner)
+        .call(virtual_staking.contract_addr.as_str())
         .unwrap_err();
 
     assert_eq!(
@@ -353,17 +359,12 @@ fn distribute_rewards_valid_amount() {
     let discount = Decimal::percent(10); // 1 OSMO worth of JUNO should give 0.9 OSMO of stake
     let native_per_foreign = Decimal::percent(40); // 1 JUNO is worth 0.4 OSMO
 
-    let app = App::new(MtApp::new(|router, _, storage| {
-        router
-            .bank
-            .init_balance(storage, &Addr::unchecked(owner), coins(99999, "TOKEN"))
-            .unwrap();
-    }));
+    let app = App::default();
 
     let SetupResponse {
         price_feed: _,
         converter,
-        ..
+        virtual_staking,
     } = setup(
         &app,
         SetupArgs {
@@ -373,6 +374,17 @@ fn distribute_rewards_valid_amount() {
             native_per_foreign,
         },
     );
+
+    app.app_mut().init_modules(|router, _, storage| {
+        router
+            .bank
+            .init_balance(
+                storage,
+                &virtual_staking.contract_addr,
+                coins(99999, "TOKEN"),
+            )
+            .unwrap();
+    });
 
     converter
         .converter_api_proxy()
@@ -387,6 +399,6 @@ fn distribute_rewards_valid_amount() {
             },
         ])
         .with_funds(&[coin(86, "TOKEN")])
-        .call(owner)
+        .call(virtual_staking.contract_addr.as_str())
         .unwrap();
 }

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 
 use cosmwasm_std::{
     coin, ensure_eq, entry_point, to_binary, Coin, CosmosMsg, CustomQuery, DepsMut,
-    DistributionMsg, Env, Event, Reply, Response, StdError, StdResult, Storage, SubMsg, Uint128,
-    Validator, WasmMsg,
+    DistributionMsg, Env, Event, Reply, Response, StdResult, Storage, SubMsg, Uint128, Validator,
+    WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
@@ -186,44 +186,70 @@ impl VirtualStakingContract<'_> {
 
     /// This is called on each successful withdrawal
     fn reply_rewards(&self, mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
-        // Find the validator to assign the rewards to
+        const BATCH: ValidatorRewardsBatch = VALIDATOR_REWARDS_BATCH;
+
+        // Find the validator to assign the new reward to
         let (target, finished) = pop_target(deps.branch())?;
 
-        // Find all the tokens received here (consider it rewards to that validator)
+        // Find all the tokens received until now
         let cfg = self.config.load(deps.storage)?;
-        let total = VALIDATOR_REWARDS_BATCH.total(deps.storage)?;
-        let reward = deps
+        let total = deps
             .querier
             .query_balance(env.contract.address, &cfg.denom)?
-            .amount
-            - total;
+            .amount;
 
-        let mut resp = Response::new();
-
-        if reward.is_zero() && (!finished || total.is_zero()) {
-            return Ok(resp);
+        if total.is_zero() {
+            // This helps avoid unnecessary store read/writes and messages sent
+            // when there's definitely nothing to do
+            return Ok(Response::new());
         }
 
-        let all_rewards = if reward.is_zero() {
-            VALIDATOR_REWARDS_BATCH.get(deps.storage)?
-        } else {
-            VALIDATOR_REWARDS_BATCH.push(deps.storage, target, reward)?
+        let new_reward_amount = total - BATCH.total(deps.storage)?;
+
+        let all_rewards = |storage| {
+            if !new_reward_amount.is_zero() {
+                let reward_info = RewardInfo {
+                    validator: target,
+                    reward: new_reward_amount,
+                };
+
+                if total == new_reward_amount {
+                    // we don't always have to read from the store to know what the
+                    // rewards queue looks like
+                    Ok(vec![reward_info])
+                } else {
+                    let mut rewards = BATCH.rewards(storage)?;
+                    rewards.push(reward_info);
+                    Ok(rewards)
+                }
+            } else {
+                BATCH.rewards(storage)
+            }
         };
 
         if finished {
-            VALIDATOR_REWARDS_BATCH.wipe(deps.storage)?;
+            let all_rewards = all_rewards(deps.storage)?;
+            BATCH.wipe(deps.storage)?;
+
             let msg = converter_api::ExecMsg::DistributeRewards {
                 payments: all_rewards,
             };
             let msg = WasmMsg::Execute {
                 contract_addr: cfg.converter.into_string(),
                 msg: to_binary(&msg)?,
-                funds: vec![coin(reward.into(), cfg.denom)],
+                funds: vec![coin(total.into(), cfg.denom)],
             };
-            resp = resp.add_message(msg);
+            Ok(Response::new().add_message(msg))
+        } else if !new_reward_amount.is_zero() {
+            // since we're not sending out the rewards batch yet, we need to persist
+            // the update for future calls
+            let all_rewards = all_rewards(deps.storage)?;
+            BATCH.set_rewards(deps.storage, &all_rewards)?;
+            BATCH.set_total(deps.storage, &total)?;
+            Ok(Response::new())
+        } else {
+            Ok(Response::new())
         }
-
-        Ok(resp)
     }
 }
 
@@ -295,35 +321,26 @@ impl<'a> ValidatorRewardsBatch<'a> {
         Ok(())
     }
 
-    fn push(
-        &self,
-        store: &mut dyn Storage,
-        validator: impl Into<String>,
-        reward: impl Into<Uint128>,
-    ) -> StdResult<Vec<RewardInfo>> {
-        let reward = reward.into();
-        self.total
-            .update(store, |old| Ok::<_, StdError>(old + reward))?;
-        self.rewards.update::<_, StdError>(store, |mut vec| {
-            vec.push(RewardInfo {
-                validator: validator.into(),
-                reward,
-            });
-            Ok(vec)
-        })
-    }
-
-    fn get(&self, store: &mut dyn Storage) -> StdResult<Vec<RewardInfo>> {
+    fn rewards(&self, store: &mut dyn Storage) -> StdResult<Vec<RewardInfo>> {
         self.rewards.load(store)
-    }
-
-    fn wipe(&self, store: &mut dyn Storage) -> StdResult<()> {
-        self.init(store)
     }
 
     /// The total of all rewards currently in the batch.
     fn total(&self, store: &mut dyn Storage) -> StdResult<Uint128> {
         self.total.load(store)
+    }
+
+    fn set_rewards(&self, store: &mut dyn Storage, rewards: &Vec<RewardInfo>) -> StdResult<()> {
+        self.rewards.save(store, rewards)
+    }
+
+    /// The total of all rewards currently in the batch.
+    fn set_total(&self, store: &mut dyn Storage, total: &Uint128) -> StdResult<()> {
+        self.total.save(store, total)
+    }
+
+    fn wipe(&self, store: &mut dyn Storage) -> StdResult<()> {
+        self.init(store)
     }
 }
 

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -194,15 +194,16 @@ impl VirtualStakingContract<'_> {
 
         // Find all the tokens received here (consider it rewards to that validator)
         let cfg = self.config.load(deps.storage)?;
+        let total = VALIDATOR_REWARDS_BATCH.total(deps.storage)?;
         let reward = deps
             .querier
             .query_balance(env.contract.address, &cfg.denom)?
             .amount
-            - VALIDATOR_REWARDS_BATCH.total(deps.storage)?;
+            - total;
 
         let mut resp = Response::new();
 
-        if reward.is_zero() && !finished {
+        if reward.is_zero() && (!finished || total.is_zero()) {
             return Ok(resp);
         }
 

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -523,7 +523,7 @@ impl ExternalStakingContract<'_> {
         ensure_eq!(
             denom,
             config.rewards_denom,
-            PaymentError::MissingDenom(denom.to_string())
+            ContractError::InvalidDenom(config.rewards_denom)
         );
 
         rewards

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -515,8 +515,8 @@ impl ExternalStakingContract<'_> {
     pub(crate) fn distribute_rewards_batch(
         &self,
         mut deps: DepsMut,
-        denom: &str,
         rewards: &[RewardInfo],
+        denom: &str,
     ) -> Result<Vec<Event>, ContractError> {
         // check we have the proper denom
         let config = self.config.load(deps.storage)?;

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -157,6 +157,7 @@ pub fn ibc_packet_receive(
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }
+        ConsumerPacket::DistributeRewards { rewards } => {}
     };
 
     // return empty success ack

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -153,11 +153,16 @@ pub fn ibc_packet_receive(
         }
         ConsumerPacket::Distribute { validator, rewards } => {
             let contract = ExternalStakingContract::new();
-            let evt = contract.distribute_rewards(deps, validator, rewards)?;
+            let evt = contract.distribute_rewards(deps, &validator, rewards)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }
-        ConsumerPacket::DistributeRewards { rewards } => {}
+        ConsumerPacket::DistributeBatch { rewards, denom } => {
+            let contract = ExternalStakingContract::new();
+            let evts = contract.distribute_rewards_batch(deps, &denom, &rewards)?;
+            let ack = ack_success(&DistributeAck {})?;
+            IbcReceiveResponse::new().set_ack(ack).add_events(evts)
+        }
     };
 
     // return empty success ack

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -159,7 +159,7 @@ pub fn ibc_packet_receive(
         }
         ConsumerPacket::DistributeBatch { rewards, denom } => {
             let contract = ExternalStakingContract::new();
-            let evts = contract.distribute_rewards_batch(deps, &denom, &rewards)?;
+            let evts = contract.distribute_rewards_batch(deps, &rewards, &denom)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_events(evts)
         }

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1175,33 +1175,6 @@ fn batch_distribution_invalid_token() {
     assert_eq!(err, ContractError::InvalidDenom(STAR.to_string()));
 }
 
-#[test]
-fn batch_distribution_invalid_validator() {
-    let owner = "owner";
-    let user = "user1";
-
-    let app = App::new_with_balances(&[(user, &coins(600, OSMO))]);
-
-    let (vault, contract) = setup(&app, owner, 100).unwrap();
-
-    let validator = contract.activate_validators(["validator1"])[0];
-
-    vault
-        .bond()
-        .with_funds(&coins(600, OSMO))
-        .call(user)
-        .unwrap();
-
-    vault.stake(&contract, user, validator, coin(200, OSMO));
-
-    assert_eq!(
-        contract
-            .distribute_batch(owner, STAR, &[(validator, 50), ("invalid", 50)])
-            .unwrap_err(),
-        ContractError::InvalidValidator("invalid".to_string()),
-    );
-}
-
 // Helpers follow!
 
 #[track_caller]

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1,17 +1,17 @@
+mod utils;
+
 use anyhow::Result as AnyResult;
 
-use cosmwasm_std::{coin, coins, to_binary, Addr, Coin, Decimal, Uint128};
-use mesh_apis::converter_api::RewardInfo;
-use mesh_apis::ibc::AddValidator;
+use cosmwasm_std::{coin, coins, to_binary, Decimal, Uint128};
 use mesh_native_staking::contract::multitest_utils::CodeId as NativeStakingCodeId;
 use mesh_native_staking::contract::InstantiateMsg as NativeStakingInstantiateMsg;
 use mesh_native_staking_proxy::contract::multitest_utils::CodeId as NativeStakingProxyCodeId;
 use mesh_vault::contract::multitest_utils::{CodeId as VaultCodeId, VaultContractProxy};
 use mesh_vault::msg::StakingInitInfo;
 
-use mesh_sync::{Tx, ValueRange};
+use mesh_sync::ValueRange;
 
-use cw_multi_test::{App as MtApp, AppResponse};
+use cw_multi_test::App as MtApp;
 use sylvia::multitest::App;
 
 use crate::contract::cross_staking::test_utils::CrossStakingApi;
@@ -20,6 +20,10 @@ use crate::error::ContractError;
 use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo, ValidatorPendingRewards};
 use crate::state::Stake;
 use crate::test_methods_impl::test_utils::TestMethods;
+use utils::{
+    assert_rewards, get_last_external_staking_pending_tx_id, AppExt as _, ContractExt as _,
+    VaultExt as _,
+};
 
 const OSMO: &str = "osmo";
 const STAR: &str = "star";
@@ -76,22 +80,6 @@ fn setup<'app>(
         .call(owner)?;
 
     Ok((vault, contract))
-}
-
-macro_rules! assert_rewards {
-    ($contract:expr, $user:expr, $validator:expr, $expected:expr) => {
-        let rewards = $contract
-            .pending_rewards($user.to_string(), $validator.to_string())
-            .unwrap()
-            .rewards;
-        let expected = $expected;
-        let actual = rewards.amount.u128();
-        assert_eq!(
-            actual, expected,
-            "expected {} reward tokens, found: {}",
-            expected, actual
-        );
-    };
 }
 
 #[test]
@@ -1173,121 +1161,4 @@ fn batch_distribution_invalid_token() {
         .distribute_batch(owner, "supertoken", &[(validator, 50)])
         .unwrap_err();
     assert_eq!(err, ContractError::InvalidDenom(STAR.to_string()));
-}
-
-// Helpers follow!
-
-#[track_caller]
-fn get_last_external_staking_pending_tx_id(
-    contract: &ExternalStakingContractProxy<MtApp>,
-) -> Option<u64> {
-    let txs = contract.all_pending_txs_desc(None, None).unwrap().txs;
-    txs.first().map(Tx::id)
-}
-
-trait AppExt {
-    fn new_with_balances(balances: &[(&str, &[Coin])]) -> Self;
-}
-
-impl AppExt for App<MtApp> {
-    #[track_caller]
-    fn new_with_balances(balances: &[(&str, &[Coin])]) -> Self {
-        let app = MtApp::new(|router, _api, storage| {
-            for (addr, coins) in balances {
-                router
-                    .bank
-                    .init_balance(storage, &Addr::unchecked(*addr), coins.to_vec())
-                    .unwrap();
-            }
-        });
-        Self::new(app)
-    }
-}
-
-type Vault<'app> = VaultContractProxy<'app, MtApp>;
-type Contract<'app> = ExternalStakingContractProxy<'app, MtApp>;
-
-trait ContractExt {
-    fn activate_validators<const N: usize>(
-        &self,
-        validators: [&'static str; N],
-    ) -> [&'static str; N];
-
-    fn distribute_batch(
-        &self,
-        caller: impl AsRef<str>,
-        denom: impl Into<String>,
-        rewards: &[(&str, u128)],
-    ) -> Result<AppResponse, ContractError>;
-}
-
-impl ContractExt for Contract<'_> {
-    #[track_caller]
-    fn activate_validators<const N: usize>(
-        &self,
-        validators: [&'static str; N],
-    ) -> [&'static str; N] {
-        for val in validators {
-            let activate = AddValidator::mock(val);
-            self.test_methods_proxy()
-                .test_set_active_validator(activate)
-                .call("test")
-                .unwrap();
-        }
-
-        validators
-    }
-
-    #[track_caller]
-    fn distribute_batch(
-        &self,
-        caller: impl AsRef<str>,
-        denom: impl Into<String>,
-        rewards: &[(&str, u128)],
-    ) -> Result<AppResponse, ContractError> {
-        let rewards: Vec<_> = rewards
-            .iter()
-            .map(|(validator, amount)| reward_info(*validator, *amount))
-            .collect();
-
-        self.test_methods_proxy()
-            .test_distribute_rewards_batch(denom.into(), rewards)
-            .call(caller.as_ref())
-    }
-}
-
-trait VaultExt {
-    fn stake(&self, contract: &Contract, user: &str, validator: impl Into<String>, coin: Coin);
-}
-
-impl VaultExt for Vault<'_> {
-    #[track_caller]
-    fn stake(&self, contract: &Contract, user: &str, validator: impl Into<String>, coin: Coin) {
-        self.stake_remote(
-            contract.contract_addr.to_string(),
-            coin,
-            to_binary(&ReceiveVirtualStake {
-                validator: validator.into(),
-            })
-            .unwrap(),
-        )
-        .call(user)
-        .unwrap();
-
-        // TODO: Hardcoded external-staking's commit_stake call (lack of IBC support yet).
-        // This should be through `IbcPacketAckMsg`
-        let last_external_staking_tx = get_last_external_staking_pending_tx_id(contract).unwrap();
-        contract
-            .test_methods_proxy()
-            .test_commit_stake(last_external_staking_tx)
-            .call("test")
-            .unwrap();
-    }
-}
-
-fn reward_info(validator: impl Into<String>, reward: u128) -> RewardInfo {
-    RewardInfo {
-        validator: validator.into(),
-        reward: reward.into(),
-    }
 }

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -97,22 +97,13 @@ fn instantiate() {
 fn staking() {
     let users = ["user1", "user2"];
     let owner = "owner";
-    let validators = ["validator1", "validator2"];
 
     let app =
         App::new_with_balances(&[(users[0], &coins(300, OSMO)), (users[1], &coins(300, OSMO))]);
 
     let (vault, contract) = setup(&app, owner, 100).unwrap();
 
-    // set these validators to be active
-    for val in validators {
-        let activate = AddValidator::mock(val);
-        contract
-            .test_methods_proxy()
-            .test_set_active_validator(activate)
-            .call("test")
-            .unwrap();
-    }
+    let validators = activate_validators(&contract, ["validator1", "validator2"]);
 
     // Bond tokens
     vault
@@ -314,19 +305,10 @@ fn unstaking() {
         App::new_with_balances(&[(users[0], &coins(300, OSMO)), (users[1], &coins(300, OSMO))]);
 
     let owner = "owner";
-    let validators = ["validator1", "validator2"];
 
     let (vault, contract) = setup(&app, owner, 100).unwrap();
 
-    // set these validators to be active
-    for val in validators {
-        let activate = AddValidator::mock(val);
-        contract
-            .test_methods_proxy()
-            .test_set_active_validator(activate)
-            .call("test")
-            .unwrap();
-    }
+    let validators = activate_validators(&contract, ["validator1", "validator2"]);
 
     // Bond and stake tokens
     //
@@ -632,19 +614,9 @@ fn distribution() {
         (owner, &[coin(1000, STAR), coin(1000, OSMO)]),
     ]);
 
-    let validators = ["validator1", "validator2"];
-
     let (vault, contract) = setup(&app, owner, 100).unwrap();
 
-    // set these validators to be active
-    for val in validators {
-        let activate = AddValidator::mock(val);
-        contract
-            .test_methods_proxy()
-            .test_set_active_validator(activate)
-            .call("test")
-            .unwrap();
-    }
+    let validators = activate_validators(&contract, ["validator1", "validator2"]);
 
     // Bond and stake tokens
     //
@@ -1326,6 +1298,8 @@ fn distribution() {
         .unwrap();
 }
 
+// Helpers follow!
+
 trait AppExt {
     fn new_with_balances(balances: &[(&str, &[Coin])]) -> Self;
 }
@@ -1342,4 +1316,20 @@ impl AppExt for App<MtApp> {
         });
         Self::new(app)
     }
+}
+
+fn activate_validators<const N: usize>(
+    contract: &ExternalStakingContractProxy<'_, MtApp>,
+    validators: [&'static str; N],
+) -> [&'static str; N] {
+    for val in validators {
+        let activate = AddValidator::mock(val);
+        contract
+            .test_methods_proxy()
+            .test_set_active_validator(activate)
+            .call("test")
+            .unwrap();
+    }
+
+    validators
 }

--- a/contracts/provider/external-staking/src/multitest/utils.rs
+++ b/contracts/provider/external-staking/src/multitest/utils.rs
@@ -1,0 +1,144 @@
+use cosmwasm_std::{to_binary, Addr, Coin};
+use cw_multi_test::{App as MtApp, AppResponse};
+use mesh_apis::{converter_api::RewardInfo, ibc::AddValidator};
+use mesh_sync::Tx;
+use mesh_vault::contract::multitest_utils::VaultContractProxy;
+use sylvia::multitest::App;
+
+use crate::{
+    contract::multitest_utils::ExternalStakingContractProxy, error::ContractError,
+    msg::ReceiveVirtualStake, test_methods_impl::test_utils::TestMethods as _,
+};
+
+macro_rules! assert_rewards {
+    ($contract:expr, $user:expr, $validator:expr, $expected:expr) => {
+        let rewards = $contract
+            .pending_rewards($user.to_string(), $validator.to_string())
+            .unwrap()
+            .rewards;
+        let expected = $expected;
+        let actual = rewards.amount.u128();
+        assert_eq!(
+            actual, expected,
+            "expected {} reward tokens, found: {}",
+            expected, actual
+        );
+    };
+}
+
+pub(crate) use assert_rewards;
+
+#[track_caller]
+pub(crate) fn get_last_external_staking_pending_tx_id(
+    contract: &ExternalStakingContractProxy<MtApp>,
+) -> Option<u64> {
+    let txs = contract.all_pending_txs_desc(None, None).unwrap().txs;
+    txs.first().map(Tx::id)
+}
+
+pub(crate) trait AppExt {
+    fn new_with_balances(balances: &[(&str, &[Coin])]) -> Self;
+}
+
+impl AppExt for App<MtApp> {
+    #[track_caller]
+    fn new_with_balances(balances: &[(&str, &[Coin])]) -> Self {
+        let app = MtApp::new(|router, _api, storage| {
+            for (addr, coins) in balances {
+                router
+                    .bank
+                    .init_balance(storage, &Addr::unchecked(*addr), coins.to_vec())
+                    .unwrap();
+            }
+        });
+        Self::new(app)
+    }
+}
+
+type Vault<'app> = VaultContractProxy<'app, MtApp>;
+type Contract<'app> = ExternalStakingContractProxy<'app, MtApp>;
+
+pub(crate) trait ContractExt {
+    fn activate_validators<const N: usize>(
+        &self,
+        validators: [&'static str; N],
+    ) -> [&'static str; N];
+
+    fn distribute_batch(
+        &self,
+        caller: impl AsRef<str>,
+        denom: impl Into<String>,
+        rewards: &[(&str, u128)],
+    ) -> Result<AppResponse, ContractError>;
+}
+
+impl ContractExt for Contract<'_> {
+    #[track_caller]
+    fn activate_validators<const N: usize>(
+        &self,
+        validators: [&'static str; N],
+    ) -> [&'static str; N] {
+        for val in validators {
+            let activate = AddValidator::mock(val);
+            self.test_methods_proxy()
+                .test_set_active_validator(activate)
+                .call("test")
+                .unwrap();
+        }
+
+        validators
+    }
+
+    #[track_caller]
+    fn distribute_batch(
+        &self,
+        caller: impl AsRef<str>,
+        denom: impl Into<String>,
+        rewards: &[(&str, u128)],
+    ) -> Result<AppResponse, ContractError> {
+        let rewards: Vec<_> = rewards
+            .iter()
+            .map(|(validator, amount)| reward_info(*validator, *amount))
+            .collect();
+
+        self.test_methods_proxy()
+            .test_distribute_rewards_batch(denom.into(), rewards)
+            .call(caller.as_ref())
+    }
+}
+
+pub(crate) trait VaultExt {
+    fn stake(&self, contract: &Contract, user: &str, validator: impl Into<String>, coin: Coin);
+}
+
+impl VaultExt for Vault<'_> {
+    #[track_caller]
+    fn stake(&self, contract: &Contract, user: &str, validator: impl Into<String>, coin: Coin) {
+        self.stake_remote(
+            contract.contract_addr.to_string(),
+            coin,
+            to_binary(&ReceiveVirtualStake {
+                validator: validator.into(),
+            })
+            .unwrap(),
+        )
+        .call(user)
+        .unwrap();
+
+        // TODO: Hardcoded external-staking's commit_stake call (lack of IBC support yet).
+        // This should be through `IbcPacketAckMsg`
+        let last_external_staking_tx = get_last_external_staking_pending_tx_id(contract).unwrap();
+        contract
+            .test_methods_proxy()
+            .test_commit_stake(last_external_staking_tx)
+            .call("test")
+            .unwrap();
+    }
+}
+
+fn reward_info(validator: impl Into<String>, reward: u128) -> RewardInfo {
+    RewardInfo {
+        validator: validator.into(),
+        reward: reward.into(),
+    }
+}

--- a/contracts/provider/external-staking/src/test_methods.rs
+++ b/contracts/provider/external-staking/src/test_methods.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{Coin, Response, StdError};
+use mesh_apis::converter_api::RewardInfo;
 use mesh_apis::ibc::AddValidator;
 use sylvia::interface;
 use sylvia::types::ExecCtx;
@@ -40,6 +41,15 @@ pub trait TestMethods {
         ctx: ExecCtx,
         validator: String,
         rewards: Coin,
+    ) -> Result<Response, Self::Error>;
+
+    /// Batch distribute rewards.
+    #[msg(exec)]
+    fn test_distribute_rewards_batch(
+        &self,
+        ctx: ExecCtx,
+        denom: String,
+        rewards: Vec<RewardInfo>,
     ) -> Result<Response, Self::Error>;
 
     /// Commits a withdraw rewards transaction.

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -114,7 +114,7 @@ impl TestMethods for ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(any(test, feature = "mt"))]
         {
-            let event = self.distribute_rewards(ctx.deps, validator, rewards)?;
+            let event = self.distribute_rewards(ctx.deps, &validator, rewards)?;
             Ok(Response::new().add_event(event))
         }
         #[cfg(not(any(test, feature = "mt")))]

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -3,6 +3,7 @@ use crate::error::ContractError;
 use crate::test_methods::TestMethods;
 
 use cosmwasm_std::{Coin, Response};
+use mesh_apis::converter_api::RewardInfo;
 use mesh_apis::ibc::AddValidator;
 use sylvia::contract;
 use sylvia::types::ExecCtx;
@@ -120,6 +121,26 @@ impl TestMethods for ExternalStakingContract<'_> {
         #[cfg(not(any(test, feature = "mt")))]
         {
             let _ = (ctx, validator, rewards);
+            Err(ContractError::Unauthorized)
+        }
+    }
+
+    /// Batch distribute rewards.
+    #[msg(exec)]
+    fn test_distribute_rewards_batch(
+        &self,
+        ctx: ExecCtx,
+        denom: String,
+        rewards: Vec<RewardInfo>,
+    ) -> Result<Response, Self::Error> {
+        #[cfg(any(test, feature = "mt"))]
+        {
+            let events = self.distribute_rewards_batch(ctx.deps, &denom, &rewards)?;
+            Ok(Response::new().add_events(events))
+        }
+        #[cfg(not(any(test, feature = "mt")))]
+        {
+            let _ = (ctx, denom, rewards);
             Err(ContractError::Unauthorized)
         }
     }

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -135,7 +135,7 @@ impl TestMethods for ExternalStakingContract<'_> {
     ) -> Result<Response, Self::Error> {
         #[cfg(any(test, feature = "mt"))]
         {
-            let events = self.distribute_rewards_batch(ctx.deps, &denom, &rewards)?;
+            let events = self.distribute_rewards_batch(ctx.deps, &rewards, &denom)?;
             Ok(Response::new().add_events(events))
         }
         #[cfg(not(any(test, feature = "mt")))]

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -46,6 +46,7 @@ pub trait ConverterApi {
 }
 
 #[cw_serde]
+#[derive(PartialOrd, Eq, Ord)]
 pub struct RewardInfo {
     pub validator: String,
     pub reward: Uint128,

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -3,6 +3,8 @@ use std::error::Error;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Binary, Coin, StdResult};
 
+use crate::converter_api::RewardInfo;
+
 /// These are messages sent from provider -> consumer
 /// ibc_packet_receive in converter must handle them all.
 /// Each one has a different ack to be used in the reply.
@@ -69,6 +71,13 @@ pub enum ConsumerPacket {
         validator: String,
         /// The amount of rewards held on the consumer side to be released later
         rewards: Coin,
+    },
+    /// This is part of the rewards protocol
+    DistributeRewards {
+        /// Per-validator reward amounts
+        rewards: Vec<RewardInfo>,
+        /// Rewards denom
+        denom: String,
     },
 }
 

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -73,7 +73,7 @@ pub enum ConsumerPacket {
         rewards: Coin,
     },
     /// This is part of the rewards protocol
-    DistributeRewards {
+    DistributeBatch {
         /// Per-validator reward amounts
         rewards: Vec<RewardInfo>,
         /// Rewards denom


### PR DESCRIPTION
Closes #77 

There's this comment in the ticket:
> This requires much more complex withdraw logic in the virtual-staking contract, and first we need to be able to cover that with unit tests.

Given that the ticket talks about batching distribution and not withdrawing, I don't understand the need for changing withdraw logic. I feel like maybe there's an implication withdrawing could be optimized too, but I have no way of knowing for sure what was meant. If I'm missing something or there's further work to be done, please let me know.

