### PR TITLE
Sync `ValsetUpdate` members

### DIFF
--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -148,10 +148,9 @@ pub(crate) fn add_validators_msg(
 pub(crate) fn tombstone_validators_msg(
     env: &Env,
     channel: &IbcChannel,
-    validators: &[Validator],
+    validators: &[String],
 ) -> Result<IbcMsg, ContractError> {
-    let updates = validators.iter().map(|v| v.address.clone()).collect();
-    let packet = ConsumerPacket::RemoveValidators(updates);
+    let packet = ConsumerPacket::RemoveValidators(Vec::from(validators));
     let msg = IbcMsg::SendPacket {
         channel_id: channel.endpoint.channel_id.clone(),
         data: to_binary(&packet)?,

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -237,12 +237,7 @@ fn valset_update_works() {
             max_change_rate: Default::default(),
         },
     ];
-    let rem_validators = vec![Validator {
-        address: "validator3".to_string(),
-        commission: Default::default(),
-        max_commission: Default::default(),
-        max_change_rate: Default::default(),
-    }];
+    let rem_validators = vec!["validator3".to_string()];
 
     // Check that only the virtual staking contract can call this handler
     let res = converter

--- a/contracts/consumer/virtual-staking/src/multitest.rs
+++ b/contracts/consumer/virtual-staking/src/multitest.rs
@@ -147,22 +147,15 @@ fn valset_update_sudo() {
             max_change_rate: Default::default(),
         },
     ];
-    let rems = vec![Validator {
-        address: "cosmosval2".to_string(),
-        commission: Decimal::percent(2),
-        max_commission: Decimal::percent(20),
-        max_change_rate: Default::default(),
-    }];
-    let tombs = vec![Validator {
-        address: "cosmosval3".to_string(),
-        commission: Decimal::percent(3),
-        max_commission: Decimal::percent(30),
-        max_change_rate: Default::default(),
-    }];
+    let rems = vec!["cosmosval2".to_string()];
+    let tombs = vec!["cosmosval3".to_string()];
     let msg = SudoMsg::ValsetUpdate {
         additions: adds,
         removals: rems,
-        tombstones: tombs,
+        updated: vec![],
+        jailed: vec![],
+        unjailed: vec![],
+        tombstoned: tombs,
     };
 
     let res = app

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -41,7 +41,7 @@ pub trait ConverterApi {
         &self,
         ctx: ExecCtx,
         additions: Vec<Validator>,
-        tombstones: Vec<Validator>,
+        tombstoned: Vec<String>,
     ) -> Result<Response, Self::Error>;
 }
 

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -36,13 +36,19 @@ pub enum SudoMsg {
     ///
     /// It should also withdraw all pending rewards here, and send them to the converter contract.
     Rebalance {},
-    /// SudoMsg::ValsetUpdate{} should be called every time there's a validator set update: addition
-    /// of a new validator to the active validator set, removal of a validator from the
-    /// active validator set, or permanent removal (i.e. tombstoning) of a validator from the active
-    /// validator set.
+    /// SudoMsg::ValsetUpdate{} should be called every time there's a validator set update:
+    ///  - Addition of a new validator to the active validator set.
+    ///  - Temporary removal of a validator from the active set. (i.e. `unbonded` state).
+    ///  - Update of validator data.
+    ///  - Temporary removal of a validator from the active set due to jailing. Implies slashing.
+    ///  - Addition of an existing validator to the active validator set.
+    ///  - Permanent removal (i.e. tombstoning) of a validator from the active set. Implies slashing
     ValsetUpdate {
         additions: Vec<Validator>,
-        removals: Vec<Validator>,
-        tombstones: Vec<Validator>,
+        removals: Vec<String>,
+        updated: Vec<Validator>,
+        jailed: Vec<String>,
+        unjailed: Vec<String>,
+        tombstoned: Vec<String>,
     },
 }


### PR DESCRIPTION
Related to #88. See also https://github.com/osmosis-labs/mesh-security/pull/109#issuecomment-1733178228.

Provide a complete API for validator set updates / sync ups fields with the SDK.