### PR TITLE
F/slashing accounting

### DIFF
--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -158,6 +158,10 @@ impl VirtualStakingContract<'_> {
 
         // Send additions and tombstones to the Converter. Removals are non-permanent and ignored
         // TODO: Send jailed even when they are non-permanent, for slashing
+        // FIXME: Account for tombstoned validators `bond_requests`. Add a `slashings` field to the config,
+        // and avoid unbondings of slashed amounts.
+        // FIXME: Account for jailed validators `bond_requests`. avoid unbondings of slashed
+        // amounts. Requires computing the slashing amount, i.e. obtaining the chain's slash_ratio.
         let cfg = self.config.load(deps.storage)?;
         let msg = converter_api::ExecMsg::ValsetUpdate {
             additions: additions.to_vec(),

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -731,7 +731,9 @@ impl ExternalStakingContract<'_> {
         for (user, ref mut stake) in users {
             let stake_low = stake.stake.low();
             let stake_high = stake.stake.high();
-            // Use the high value for consistency (for vault's accounting)
+            // Calculating slashing with always the `high` value of the range goes against the user
+            // in some scenario (pending stakes while slashing); but the scenario is relatively
+            // unlikely.
             let stake_slash = stake_high * config.max_slashing;
             // Requires proper saturating methods in commit/rollback_stake/unstake
             stake.stake = ValueRange::new(

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -740,7 +740,17 @@ impl ExternalStakingContract<'_> {
                 stake_low.saturating_sub(stake_slash),
                 stake_high - stake_slash,
             );
-            // TODO: Points alignment
+
+            // Distribution alignment
+            let mut distribution = self
+                .distribution
+                .may_load(storage, validator)?
+                .unwrap_or_default();
+            stake
+                .points_alignment
+                .stake_decreased(stake_slash, distribution.points_per_stake);
+            distribution.total_stake -= stake_slash;
+            self.distribution.save(storage, validator, &distribution)?;
 
             // Slash the unbondings
             let pending_slashed = stake.slash_pending(&env.block, config.max_slashing);

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -741,13 +741,13 @@ impl ExternalStakingContract<'_> {
             // TODO: Points alignment
 
             // Slash the unbondings
-            let pending_slashable = stake.slash_pending(&env.block, config.max_slashing);
+            let pending_slashed = stake.slash_pending(&env.block, config.max_slashing);
 
             self.stakes.stake.save(storage, (&user, validator), stake)?;
 
             slash_infos.push(SlashInfo {
                 user: user.to_string(),
-                stake: stake_high + pending_slashable,
+                slash: stake_slash + pending_slashed,
             });
         }
 

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -707,6 +707,7 @@ impl ExternalStakingContract<'_> {
     /// handler)
     pub(crate) fn handle_slashing(
         &self,
+        env: &Env,
         storage: &mut dyn Storage,
         validator: &str,
     ) -> Result<WasmMsg, ContractError> {
@@ -735,12 +736,14 @@ impl ExternalStakingContract<'_> {
                 stake_low - stake_low * config.max_slashing,
                 stake_high - stake_high * config.max_slashing,
             );
-            self.stakes
-                .stake
-                .save(storage, (&user, validator), &slashed_stake)?;
             // TODO: Points alignment
 
             // Slash the unbondings
+            slashed_stake.slash_pending(&env.block, config.max_slashing);
+
+            self.stakes
+                .stake
+                .save(storage, (user, validator), &slashed_stake)?;
         }
 
         // Route associated users to vault for slashing of their collateral

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -731,10 +731,12 @@ impl ExternalStakingContract<'_> {
         for (user, ref mut stake) in users {
             let stake_low = stake.stake.low();
             let stake_high = stake.stake.high();
+            // Use the high value for consistency (for vault's accounting)
+            let stake_slash = stake_high * config.max_slashing;
             // Requires proper saturating methods in commit/rollback_stake/unstake
             stake.stake = ValueRange::new(
-                stake_low - stake_low * config.max_slashing,
-                stake_high - stake_high * config.max_slashing,
+                stake_low.saturating_sub(stake_slash),
+                stake_high - stake_slash,
             );
             // TODO: Points alignment
 

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -723,7 +723,7 @@ impl ExternalStakingContract<'_> {
             .map(|item| {
                 let ((user, _), stake) = item?;
                 Ok::<_, ContractError>(SlashInfo {
-                    user,
+                    user: user.to_string(),
                     stake: stake.stake.high(),
                 })
             })

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -117,7 +117,7 @@ pub fn ibc_channel_close(
 // this accepts validator sync packets and updates the crdt state
 pub fn ibc_packet_receive(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     msg: IbcPacketReceiveMsg,
 ) -> Result<IbcReceiveResponse, ContractError> {
     // There is only one channel, so we don't need to switch.
@@ -163,7 +163,7 @@ pub fn ibc_packet_receive(
                 if active {
                     // slash the validator
                     // TODO: Error handling / capturing
-                    let msg = contract.handle_slashing(deps.storage, &valoper)?;
+                    let msg = contract.handle_slashing(&env, deps.storage, &valoper)?;
                     msgs.push(msg);
                 }
             }

--- a/contracts/provider/external-staking/src/stakes.rs
+++ b/contracts/provider/external-staking/src/stakes.rs
@@ -4,7 +4,7 @@ use cw_storage_plus::{Index, IndexList, IndexedMap, KeyDeserialize, MultiIndex};
 
 pub struct StakeIndexes<'a> {
     // Last type param defines the pk deserialization type
-    pub rev: MultiIndex<'a, (String, Addr), Stake, (String, Addr)>,
+    pub rev: MultiIndex<'a, (String, Addr), Stake, (Addr, String)>,
 }
 
 impl<'a> IndexList<Stake> for StakeIndexes<'a> {
@@ -50,7 +50,7 @@ impl<'a> Stakes<'a> {
             .sub_prefix(validator.to_string())
             .range(storage, None, None, Order::Ascending)
             .map(|item| {
-                let ((_, user), stake) = item?;
+                let ((user, _), stake) = item?;
                 Ok((user, stake))
             })
             .collect::<StdResult<Vec<(Addr, Stake)>>>()

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -25,7 +25,7 @@ pub struct Config {
 #[cw_serde]
 #[derive(Default)]
 pub struct Stake {
-    /// How much tokens user staken and not in unbonding period
+    /// How much tokens user stake and not in unbonding period
     /// via this contract
     pub stake: ValueRange<Uint128>,
     /// List of token batches scheduled for unbonding
@@ -34,7 +34,7 @@ pub struct Stake {
     /// `unbonding_period` after current time - this way this is guaranteed to be
     /// always sorted (as time is guaranteed to be monotonic).
     pub pending_unbonds: Vec<PendingUnbond>,
-    /// Points alignment is how much points should be added/substracted from points caltulated per
+    /// Points alignment is how much points should be added/subtracted from points calculated per
     /// user due to stake changes.
     pub points_alignment: PointsAlignment,
     /// Tokens already withdrawn by this user

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -89,22 +89,17 @@ impl Stake {
     /// Slashes all the entries in `pending_unbonds`, returning total slashed amount.
     pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) -> Uint128 {
         let mut slashed = Uint128::zero();
-        self.pending_unbonds = self
+        let _ = self
             .pending_unbonds
-            .iter()
-            .map(|pending| PendingUnbond {
-                amount: if pending.release_at >= info.time {
-                    // Compute total slashable
-                    let slash = pending.amount * slash_ratio;
-                    slashed += slash;
-                    // Slash it
-                    pending.amount - slash
-                } else {
-                    pending.amount
-                },
-                release_at: pending.release_at,
-            })
-            .collect();
+            .iter_mut()
+            .filter(|pending| pending.release_at >= info.time)
+            .map(|pending| {
+                let slash = pending.amount * slash_ratio;
+                // Add to total slashed
+                slashed += slash;
+                // Slash it
+                pending.amount -= slash
+            });
         slashed
     }
 }

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -85,6 +85,22 @@ impl Stake {
             .map(|pending| pending.amount)
             .sum()
     }
+
+    /// Slashes all the entries in `pending_unbonds`.
+    pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) {
+        self.pending_unbonds = self
+            .pending_unbonds
+            .iter()
+            .map(|pending| PendingUnbond {
+                amount: if pending.release_at > info.time {
+                    pending.amount - pending.amount * slash_ratio
+                } else {
+                    pending.amount
+                },
+                release_at: pending.release_at,
+            })
+            .collect();
+    }
 }
 
 /// Per validator distribution information

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -86,25 +86,26 @@ impl Stake {
             .sum()
     }
 
-    /// Slashes all the entries in `pending_unbonds`, returning total slashable amount.
+    /// Slashes all the entries in `pending_unbonds`, returning total slashed amount.
     pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) -> Uint128 {
-        let mut slashable = Uint128::zero();
+        let mut slashed = Uint128::zero();
         self.pending_unbonds = self
             .pending_unbonds
             .iter()
             .map(|pending| PendingUnbond {
                 amount: if pending.release_at >= info.time {
                     // Compute total slashable
-                    slashable += pending.amount;
+                    let slash = pending.amount * slash_ratio;
+                    slashed += slash;
                     // Slash it
-                    pending.amount - pending.amount * slash_ratio
+                    pending.amount - slash
                 } else {
                     pending.amount
                 },
                 release_at: pending.release_at,
             })
             .collect();
-        slashable
+        slashed
     }
 }
 

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -192,7 +192,7 @@ impl TestMethods for ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(any(test, feature = "mt"))]
         {
-            let msg = self.handle_slashing(ctx.deps.storage, &validator)?;
+            let msg = self.handle_slashing(&ctx.env, ctx.deps.storage, &validator)?;
             Ok(Response::new().add_message(msg))
         }
         #[cfg(not(any(test, feature = "mt")))]

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -732,7 +732,7 @@ impl VaultContract<'_> {
             let mut lien = self
                 .liens
                 .load(ctx.deps.storage, (&slash_user, &lien_holder))?;
-            let slash_amount = slash.stake * lien.slashable;
+            let slash_amount = slash.slash;
             let mut user_info = self.users.load(ctx.deps.storage, &slash_user)?;
             let new_collateral = user_info.collateral - slash_amount;
 

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -748,7 +748,6 @@ impl VaultContract<'_> {
             self.recalculate_max_lien(ctx.deps.storage, &slash_user, &mut user_info)?;
             // Get free collateral before adjusting collateral, but after slashing
             let free_collateral = user_info.free_collateral().low(); // For simplicity
-                                                                     // TODO: Remove required amount from the user's stake (needs rebalance msg)
             if free_collateral < slash_amount {
                 // Check / adjust mesh security invariants according to the new collateral
                 self.propagate_slash(

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -49,7 +49,7 @@ pub trait VaultApi {
 #[cw_serde]
 pub struct SlashInfo {
     pub user: String,
-    pub stake: Uint128,
+    pub slash: Uint128,
 }
 
 #[cw_serde]


### PR DESCRIPTION
Closes part of #128.

- [x] `external-staking` slashing acct.
- [x] `external-staking` slashing acct tests.
- [ ] slashing over pending unbondings test.
- [ ] slashing during pending tx tests.
  - [ ] slash during successful unbond.
  - [ ] slash during failing unbond.
  - [ ] slash during successful bond.
  - [ ] slash during failing bond.