### PR TITLE
Fix validator withdrawal follow-up

### DIFF
--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
 
 use cosmwasm_std::{
     coin, ensure_eq, entry_point, to_binary, Coin, CosmosMsg, CustomQuery, Decimal, DepsMut,
@@ -131,9 +132,8 @@ impl VirtualStakingContract<'_> {
         if !tombstoned.is_empty() || !jailed.is_empty() {
             let slash_ratio = if !jailed.is_empty() {
                 // Only query if needed
-                // TODO: Slash ratio query
-                // Decimal::percent(TokenQuerier::new(&deps.querier).slash_ratio()?);
-                Decimal::percent(10)
+                let ratios = TokenQuerier::new(&deps.querier).slash_ratio()?;
+                Decimal::from_str(&ratios.slash_fraction_downtime)?
             } else {
                 Decimal::zero()
             };

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -216,8 +216,6 @@ impl VirtualStakingContract<'_> {
         unjailed: &[String],
         tombstoned: &[String],
     ) -> Result<Response<VirtualStakeCustomMsg>, ContractError> {
-        // TODO: Store/process removals locally, so that they are filtered out from
-        // the `bonded` list
         let _ = (removals, updated, unjailed);
 
         // Account for tombstoned validators. Will be processed in handle_epoch

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -17,6 +17,10 @@ pub enum VirtualStakeQuery {
     /// it will return zero values rather than an error.
     #[returns(BondStatusResponse)]
     BondStatus { contract: String },
+
+    /// Returns the blockchain's slashing ratios.
+    #[returns(SlashRatioResponse)]
+    SlashRatio {},
 }
 
 /// Bookkeeping info in the virtual staking sdk module
@@ -28,6 +32,14 @@ pub struct BondStatusResponse {
     /// Number of tokens than already have been minted by this address.
     /// Trying to mint more than (cap - currently_minted) will fail.
     pub delegated: Coin,
+}
+
+#[cw_serde]
+pub struct SlashRatioResponse {
+    /// Slash ratio due to downtime. Used for temporary jailing.
+    pub slash_fraction_downtime: String,
+    /// Slash ratio due to double signing. Applied when a validator is permanently jailed (tombstoned).
+    pub slash_fraction_double_sign: String,
 }
 
 impl CustomQuery for VirtualStakeCustomQuery {}
@@ -49,7 +61,12 @@ impl<'a> TokenQuerier<'a> {
     }
 
     pub fn bond_status(&self, contract: String) -> StdResult<BondStatusResponse> {
-        let full_denom_query = VirtualStakeQuery::BondStatus { contract };
-        self.querier.query(&full_denom_query.into())
+        let bond_status_query = VirtualStakeQuery::BondStatus { contract };
+        self.querier.query(&bond_status_query.into())
+    }
+
+    pub fn slash_ratio(&self) -> StdResult<SlashRatioResponse> {
+        let slash_ratio_query = VirtualStakeQuery::SlashRatio {};
+        self.querier.query(&slash_ratio_query.into())
     }
 }


### PR DESCRIPTION
Process jailing and tombstoning events in `virtual-staking`, adjusting the bonded amounts so that they are consistent with their on-chain slashing.

#132 tests can now be extended to these scenarios.