### PR TITLE
F/slashing accounting tests

### DIFF
--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1619,7 +1619,10 @@ fn slashing_pending_tx_bond() {
     let claim = vault
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
-    assert_eq!(claim.amount, ValueRange::new(Uint128::new(250), Uint128::new(300)));
+    assert_eq!(
+        claim.amount,
+        ValueRange::new(Uint128::new(250), Uint128::new(300))
+    );
 
     // Now validators[0] slashing happens
     contract
@@ -1632,7 +1635,10 @@ fn slashing_pending_tx_bond() {
     let claim = vault
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
-    assert_eq!(claim.amount, ValueRange::new(Uint128::new(225), Uint128::new(275)));
+    assert_eq!(
+        claim.amount,
+        ValueRange::new(Uint128::new(225), Uint128::new(275))
+    );
 
     // Now the extra bond gets committed (i.e. successful)
     contract
@@ -1677,7 +1683,7 @@ fn slashing_pending_tx_bond_rolled_back() {
             to_binary(&ReceiveVirtualStake {
                 validator: validators[0].into(),
             })
-                .unwrap(),
+            .unwrap(),
         )
         .call(user)
         .unwrap();
@@ -1700,7 +1706,10 @@ fn slashing_pending_tx_bond_rolled_back() {
     let claim = vault
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
-    assert_eq!(claim.amount, ValueRange::new(Uint128::new(250), Uint128::new(300)));
+    assert_eq!(
+        claim.amount,
+        ValueRange::new(Uint128::new(250), Uint128::new(300))
+    );
 
     // Now validators[0] slashing happens
     contract
@@ -1713,7 +1722,10 @@ fn slashing_pending_tx_bond_rolled_back() {
     let claim = vault
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
-    assert_eq!(claim.amount, ValueRange::new(Uint128::new(225), Uint128::new(275)));
+    assert_eq!(
+        claim.amount,
+        ValueRange::new(Uint128::new(225), Uint128::new(275))
+    );
 
     // Now the extra bond gets rolled back (i.e. failed)
     contract

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1483,3 +1483,86 @@ fn slashing_pending_tx_full_unbond() {
         .unwrap();
     assert_eq!(claim.amount.val().unwrap().u128(), 0);
 }
+
+#[test]
+fn slashing_pending_tx_full_unbond_fails() {
+    let user = "user1";
+
+    let app = App::new_with_balances(&[(user, &coins(200, OSMO))]);
+
+    let owner = "owner";
+
+    let (vault, contract) = setup(&app, owner, 100).unwrap();
+
+    let validators = contract.activate_validators(["validator1"]);
+
+    vault
+        .bond()
+        .with_funds(&coins(200, OSMO))
+        .call(user)
+        .unwrap();
+
+    vault.stake(&contract, user, validators[0], coin(200, OSMO));
+
+    // Unstake all tokens
+    contract
+        .unstake(validators[0].to_string(), coin(200, OSMO))
+        .call(user)
+        .unwrap();
+
+    // Unstaken should be immediately visible on staked amount (as pending tx)
+    let stake = contract
+        .stake(user.to_string(), validators[0].to_string())
+        .unwrap();
+    assert_eq!(
+        stake.stake,
+        ValueRange::new(Uint128::new(0), Uint128::new(200))
+    );
+
+    // Now validators[0] slashing happens
+    contract
+        .test_methods_proxy()
+        .test_handle_slashing(validators[0].to_string())
+        .call("test")
+        .unwrap();
+
+    // Claims on vault got reduced, for high end of pending unbond
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount.val().unwrap().u128(), 180);
+
+    // Now the unbond gets rolled back (i.e. failed)
+    contract
+        .test_methods_proxy()
+        .test_rollback_unstake(get_last_external_staking_pending_tx_id(&contract).unwrap())
+        .call("test")
+        .unwrap();
+
+    // Claims on vault are still unchanged
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount.val().unwrap().u128(), 180);
+
+    // Time travel - just enough for unbond to release,
+    app.app_mut().update_block(|block| {
+        block.height += 2;
+        block.time = block.time.plus_seconds(100);
+    });
+
+    // Claims on vault are still unchanged
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount.val().unwrap().u128(), 180);
+
+    // Withdrawing liens
+    contract.withdraw_unbonded().call(user).unwrap();
+
+    // Claims on vault are still unchanged
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount.val().unwrap().u128(), 180);
+}

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1485,7 +1485,7 @@ fn slashing_pending_tx_full_unbond() {
 }
 
 #[test]
-fn slashing_pending_tx_full_unbond_fails() {
+fn slashing_pending_tx_full_unbond_rolled_back() {
     let user = "user1";
 
     let app = App::new_with_balances(&[(user, &coins(200, OSMO))]);
@@ -1646,4 +1646,85 @@ fn slashing_pending_tx_bond() {
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
     assert_eq!(claim.amount.val().unwrap().u128(), 275);
+}
+
+#[test]
+fn slashing_pending_tx_bond_rolled_back() {
+    let user = "user1";
+
+    let app = App::new_with_balances(&[(user, &coins(300, OSMO))]);
+
+    let owner = "owner";
+
+    let (vault, contract) = setup(&app, owner, 100).unwrap();
+
+    let validators = contract.activate_validators(["validator1", "validator2"]);
+
+    vault
+        .bond()
+        .with_funds(&coins(300, OSMO))
+        .call(user)
+        .unwrap();
+
+    vault.stake(&contract, user, validators[0], coin(200, OSMO));
+    vault.stake(&contract, user, validators[1], coin(50, OSMO));
+
+    // Stake some more tokens (but don't commit them!)
+    vault
+        .stake_remote(
+            contract.contract_addr.to_string(),
+            coin(50, OSMO),
+            to_binary(&ReceiveVirtualStake {
+                validator: validators[0].into(),
+            })
+                .unwrap(),
+        )
+        .call(user)
+        .unwrap();
+
+    // Staken should be immediately visible on staked amount (as pending tx)
+    let stake = contract
+        .stake(user.to_string(), validators[0].to_string())
+        .unwrap();
+    assert_eq!(
+        stake.stake,
+        ValueRange::new(Uint128::new(200), Uint128::new(250))
+    );
+
+    let stake = contract
+        .stake(user.to_string(), validators[1].to_string())
+        .unwrap();
+    assert_eq!(stake.stake, ValueRange::new_val(Uint128::new(50)));
+
+    // Claims on vault got adjusted, to account for pending bond
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount, ValueRange::new(Uint128::new(250), Uint128::new(300)));
+
+    // Now validators[0] slashing happens
+    contract
+        .test_methods_proxy()
+        .test_handle_slashing(validators[0].to_string())
+        .call("test")
+        .unwrap();
+
+    // Claims on vault got reduced, for high end of pending slashed bond
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount, ValueRange::new(Uint128::new(225), Uint128::new(275)));
+
+    // Now the extra bond gets rolled back (i.e. failed)
+    contract
+        .test_methods_proxy()
+        .test_rollback_stake(get_last_external_staking_pending_tx_id(&contract).unwrap())
+        .call("test")
+        .unwrap();
+
+    // Claims on vault are now committed
+    let claim = vault
+        .claim(user.to_owned(), contract.contract_addr.to_string())
+        .unwrap();
+    assert_eq!(claim.amount.val().unwrap().u128(), 225);
 }

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -88,8 +88,7 @@ impl Stake {
 
     /// Slashes all the entries in `pending_unbonds`, returning total slashed amount.
     pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) -> Uint128 {
-        self
-            .pending_unbonds
+        self.pending_unbonds
             .iter_mut()
             .filter(|pending| pending.release_at >= info.time)
             .map(|pending| {

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -88,19 +88,17 @@ impl Stake {
 
     /// Slashes all the entries in `pending_unbonds`, returning total slashed amount.
     pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) -> Uint128 {
-        let mut slashed = Uint128::zero();
-        let _ = self
+        self
             .pending_unbonds
             .iter_mut()
             .filter(|pending| pending.release_at >= info.time)
             .map(|pending| {
                 let slash = pending.amount * slash_ratio;
-                // Add to total slashed
-                slashed += slash;
                 // Slash it
-                pending.amount -= slash
-            });
-        slashed
+                pending.amount -= slash;
+                slash
+            })
+            .sum()
     }
 }
 

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -90,7 +90,7 @@ impl Stake {
     pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) -> Uint128 {
         self.pending_unbonds
             .iter_mut()
-            .filter(|pending| pending.release_at >= info.time)
+            .filter(|pending| pending.release_at > info.time)
             .map(|pending| {
                 let slash = pending.amount * slash_ratio;
                 // Slash it


### PR DESCRIPTION
#133 follow up. Slashing accounting tests.
- [x] slashing over pending unbondings basic test.
- [x] slashing over pending unbondings adv tests (include unbonded period expiration).
- [x] slashing during pending tx tests.
  - [x] slash during successful unbond.
  - [x] slash during failing unbond.
  - [x] slash during successful bond.
  - [x] slash during failing bond.