### PR TITLE
Refactor: validator state to support multiple states

### DIFF
--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -351,10 +351,10 @@ impl ConverterApi for ConverterContract<'_> {
         &self,
         ctx: ExecCtx,
         additions: Vec<Validator>,
-        _removals: Vec<String>,
-        _updated: Vec<Validator>,
+        removals: Vec<String>,
+        updated: Vec<Validator>,
         jailed: Vec<String>,
-        _unjailed: Vec<String>,
+        unjailed: Vec<String>,
         tombstoned: Vec<String>,
     ) -> Result<Response, Self::Error> {
         self.ensure_authorized(&ctx.deps, &ctx.info)?;
@@ -374,8 +374,24 @@ impl ConverterApi for ConverterContract<'_> {
                     .join(","),
             );
         }
+        if !removals.is_empty() {
+            event = event.add_attribute("removals", removals.join(","));
+        }
+        if !updated.is_empty() {
+            event = event.add_attribute(
+                "updated",
+                updated
+                    .iter()
+                    .map(|v| v.address.clone())
+                    .collect::<Vec<String>>()
+                    .join(","),
+            );
+        }
         if !jailed.is_empty() {
             event = event.add_attribute("jailed", jailed.join(","));
+        }
+        if !unjailed.is_empty() {
+            event = event.add_attribute("unjailed", unjailed.join(","));
         }
         if !tombstoned.is_empty() {
             event = event.add_attribute("tombstoned", tombstoned.join(","));
@@ -386,10 +402,10 @@ impl ConverterApi for ConverterContract<'_> {
                 &ctx.env,
                 &channel,
                 &additions,
-                &[],
-                &[],
+                &removals,
+                &updated,
                 &jailed,
-                &[],
+                &unjailed,
                 &tombstoned,
             )?;
             resp = resp.add_message(valset_msg);

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -351,8 +351,11 @@ impl ConverterApi for ConverterContract<'_> {
         &self,
         ctx: ExecCtx,
         additions: Vec<Validator>,
-        tombstoned: Vec<String>,
+        _removals: Vec<String>,
+        _updated: Vec<Validator>,
         jailed: Vec<String>,
+        _unjailed: Vec<String>,
+        tombstoned: Vec<String>,
     ) -> Result<Response, Self::Error> {
         self.ensure_authorized(&ctx.deps, &ctx.info)?;
 

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -243,13 +243,20 @@ fn valset_update_works() {
     // Check that only the virtual staking contract can call this handler
     let res = converter
         .converter_api_proxy()
-        .valset_update(vec![], vec![], vec![])
+        .valset_update(vec![], vec![], vec![], vec![], vec![], vec![])
         .call(owner);
     assert_eq!(res.unwrap_err(), Unauthorized {});
 
     let res = converter
         .converter_api_proxy()
-        .valset_update(add_validators, rem_validators, vec![])
+        .valset_update(
+            add_validators,
+            rem_validators,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        )
         .call(virtual_staking.contract_addr.as_ref());
 
     // This fails because of lack of IBC support in mt now.
@@ -304,7 +311,7 @@ fn unauthorized() {
 
     let err = converter
         .converter_api_proxy()
-        .valset_update(vec![], vec![], vec![])
+        .valset_update(vec![], vec![], vec![], vec![], vec![], vec![])
         .call("mallory")
         .unwrap_err();
 

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -236,13 +236,15 @@ impl VirtualStakingContract<'_> {
             Ok::<_, ContractError>(old)
         })?;
 
-        // Send additions and tombstones to the Converter. Removals are non-permanent and ignored.
-        // Send jailed even when they are non-permanent, for slashing.
+        // Send all updates to the Converter.
         let cfg = self.config.load(deps.storage)?;
         let msg = converter_api::ExecMsg::ValsetUpdate {
             additions: additions.to_vec(),
-            tombstoned: tombstoned.to_vec(),
+            removals: removals.to_vec(),
+            updated: updated.to_vec(),
             jailed: jailed.to_vec(),
+            unjailed: unjailed.to_vec(),
+            tombstoned: tombstoned.to_vec(),
         };
         let msg = WasmMsg::Execute {
             contract_addr: cfg.converter.to_string(),

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -22,7 +22,7 @@ use crate::error::ContractError;
 use crate::ibc::{packet_timeout, IBC_CHANNEL};
 use crate::msg::{
     AllPendingRewards, AllTxsResponse, AuthorizedEndpointResponse, ConfigResponse,
-    IbcChannelResponse, ListRemoteValidatorsResponse, ListValidatorsResponse, PendingRewards,
+    IbcChannelResponse, ListActiveValidatorsResponse, ListValidatorsResponse, PendingRewards,
     StakeInfo, StakesResponse, TxResponse, ValidatorPendingRewards,
 };
 use crate::stakes::Stakes;
@@ -911,17 +911,17 @@ impl ExternalStakingContract<'_> {
 
     /// Show all external validators that we know to be active (and can delegate to)
     #[msg(query)]
-    pub fn list_remote_validators(
+    pub fn list_active_validators(
         &self,
         ctx: QueryCtx,
         start_after: Option<String>,
         limit: Option<u64>,
-    ) -> Result<ListRemoteValidatorsResponse, ContractError> {
+    ) -> Result<ListActiveValidatorsResponse, ContractError> {
         let limit = limit.unwrap_or(100) as usize;
         let validators =
             self.val_set
                 .list_active_validators(ctx.deps.storage, start_after.as_deref(), limit)?;
-        Ok(ListRemoteValidatorsResponse { validators })
+        Ok(ListActiveValidatorsResponse { validators })
     }
 
     /// Show all external validators that we know about, along with their state.

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1247,8 +1247,10 @@ mod tests {
     use cosmwasm_std::{Attribute, Decimal, DepsMut};
 
     use crate::crdt::State;
-    use crate::msg::{AuthorizedEndpoint, ValidatorState};
+    use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, ValidatorState};
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use mesh_apis::cross_staking_api::CrossStakingApi;
+    use mesh_apis::vault_api::VaultApiExecMsg::CrossSlash;
 
     static OSMO: &str = "uosmo";
     static CREATOR: &str = "staking"; // The creator of the proxy contract(s) is the staking contract
@@ -1360,6 +1362,121 @@ mod tests {
                     validator: "carl".to_string(),
                     state: State::Active {}
                 }
+            ]
+        );
+    }
+
+    #[test]
+    fn valset_update_tombstoning_slashes() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add three new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Cross stake with bob
+        let mut stake_deps = ctx.deps.branch();
+        let vault_info = mock_info("vault_addr", &[]);
+        let stake_ctx = ExecCtx {
+            deps: stake_deps.branch(),
+            env: mock_env(),
+            info: vault_info,
+        };
+        contract
+            .receive_virtual_stake(
+                stake_ctx,
+                OWNER.to_string(),
+                coin(100, "uosmo"),
+                1,
+                to_binary(&ReceiveVirtualStake {
+                    validator: "bob".to_string(),
+                })
+                .unwrap(),
+            )
+            .unwrap();
+        // Commit it
+        contract.commit_stake(stake_deps, 1).unwrap();
+
+        // Bob is tombstoned next
+        let update_ctx = ctx.branch();
+        let tombs = vec!["bob".to_string()];
+        let (evt, msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &tombs,
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("tombstoned", "bob"),]);
+
+        // Check the slashing message
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            msgs[0],
+            WasmMsg::Execute {
+                contract_addr: "vault_addr".to_string(),
+                msg: to_binary(&CrossSlash {
+                    slashes: vec![SlashInfo {
+                        user: OWNER.to_string(),
+                        slash: Uint128::new(10),
+                    }],
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+        );
+
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Tombstoned {}
+                },
             ]
         );
     }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -471,7 +471,7 @@ impl ExternalStakingContract<'_> {
             // Maintenance
             valopers.insert(valoper.clone());
         }
-        // Process additions. Already existing validators will be ignored.
+        // Process additions. Already existing validators will be updated and set to active.
         // If the validator is tombstoned, this will be ignored.
         for AddValidator { valoper, pub_key } in additions {
             self.val_set

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -467,8 +467,7 @@ impl ExternalStakingContract<'_> {
 
                 Ok(released)
             })
-            .fold(Ok(Uint128::zero()), |acc, released| {
-                let acc = acc?;
+            .try_fold(Uint128::zero(), |acc, released| {
                 released.map(|released| released + acc)
             })?;
 

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -503,19 +503,7 @@ impl ExternalStakingContract<'_> {
             // Maintenance
             valopers.insert(valoper.clone());
         }
-        // Process unjailings. Non-existent validators will be ignored.
-        // If the validator is not in the `removals` list, it will be set to active. Otherwise, it will
-        // be ignored (set to unbonded in removals processing).
-        if !unjailed.is_empty() {
-            let unjails: HashSet<_> = unjailed.iter().collect();
-            let rems: HashSet<_> = removals.iter().collect();
-            for &valoper in unjails.difference(&rems) {
-                self.val_set
-                    .unjail_validator(deps.storage, valoper, height, time)?;
-                // Maintenance
-                valopers.insert(valoper.clone());
-            }
-        }
+        // Unjailing does nothing at the moment
         // Process updates. Non-existent and tombstoned validators will be ignored.
         for AddValidator { valoper, pub_key } in updated {
             self.val_set

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1897,6 +1897,106 @@ mod tests {
     }
 
     #[test]
+    fn valset_update_unjailing_noop() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add three new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Bob is jailed next
+        let update_ctx = ctx.branch();
+        let jails = vec!["bob".to_string()];
+        let (evt, msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &[],
+                &jails,
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("jailed", "bob"),]);
+
+        // Check there's no message
+        assert_eq!(msgs.len(), 0);
+
+        // Bob is unjailed next
+        let update_ctx = ctx.branch();
+        let unjails = vec!["bob".to_string()];
+        let (evt, _msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &[],
+                &[],
+                &unjails,
+                &[],
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("unjailed", "bob"),]);
+
+        // Check that unjail is a no-op
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Jailed {}
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn valset_update_jailing_slashes() {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -515,9 +515,13 @@ impl ExternalStakingContract<'_> {
             // Maintenance
             valopers.insert(valoper.clone());
         }
-        // Maintenance. Drain events that are older than unbonding period
+        // Maintenance. Drain events that are older than unbonding period from now
         let cfg = self.config.load(deps.storage)?;
-        let max_time = time.saturating_sub(cfg.unbonding_period);
+        let max_time = env
+            .block
+            .time
+            .seconds()
+            .saturating_sub(cfg.unbonding_period);
         for valoper in valopers {
             self.val_set.drain_older(deps.storage, &valoper, max_time)?;
         }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -517,6 +517,7 @@ impl ExternalStakingContract<'_> {
         }
         // Maintenance. Drain events that are older than unbonding period from now
         let cfg = self.config.load(deps.storage)?;
+        // Assumes time keeping is the same in both chains
         let max_time = env
             .block
             .time

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1424,7 +1424,7 @@ mod tests {
                 .unwrap(),
             )
             .unwrap();
-        // Commit it
+        // Commit stake
         contract.commit_stake(stake_deps, 1).unwrap();
 
         // Bob is tombstoned next
@@ -1653,7 +1653,7 @@ mod tests {
                     .unwrap(),
             )
             .unwrap();
-        // Commit it
+        // Commit stake
         contract.commit_stake(stake_deps, 1).unwrap();
 
         // OWNER then cross-unstakes half of the stake
@@ -1891,6 +1891,120 @@ mod tests {
                 ValidatorState {
                     validator: "carl".to_string(),
                     state: State::Tombstoned {}
+                },
+            ]
+        );
+    }
+    #[test]
+    fn valset_update_jailing_slashes() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add three new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Cross stake with bob
+        let mut stake_deps = ctx.deps.branch();
+        let vault_info = mock_info("vault_addr", &[]);
+        let stake_ctx = ExecCtx {
+            deps: stake_deps.branch(),
+            env: mock_env(),
+            info: vault_info,
+        };
+        contract
+            .receive_virtual_stake(
+                stake_ctx,
+                OWNER.to_string(),
+                coin(100, "uosmo"),
+                1,
+                to_binary(&ReceiveVirtualStake {
+                    validator: "bob".to_string(),
+                })
+                    .unwrap(),
+            )
+            .unwrap();
+        // Commit stake
+        contract.commit_stake(stake_deps, 1).unwrap();
+
+        // Bob is jailed next
+        let update_ctx = ctx.branch();
+        let jails = vec!["bob".to_string()];
+        let (evt, msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &[],
+                &jails,
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("jailed", "bob"),]);
+
+        // Check the slashing message
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            msgs[0],
+            WasmMsg::Execute {
+                contract_addr: "vault_addr".to_string(),
+                msg: to_binary(&CrossSlash {
+                    slashes: vec![SlashInfo {
+                        user: OWNER.to_string(),
+                        slash: Uint128::new(10),
+                    }],
+                })
+                    .unwrap(),
+                funds: vec![],
+            }
+        );
+
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Jailed {}
                 },
             ]
         );

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -503,7 +503,9 @@ impl ExternalStakingContract<'_> {
             // Maintenance
             valopers.insert(valoper.clone());
         }
-        // Unjailing does nothing at the moment
+        // Process unjailings. Does nothing at the moment, as we don't have a way to know if we the
+        // validator must go to the active or the unbonded state.
+
         // Process updates. Non-existent and tombstoned validators will be ignored.
         for AddValidator { valoper, pub_key } in updated {
             self.val_set

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1679,4 +1679,88 @@ mod tests {
             ]
         );
     }
+
+    /// Tombstoning of a nonexistent validator is supported for robustness.
+    /// No slashing is performed (non-existent validator assumed to be inactive).
+    #[test]
+    fn valset_update_tombstoning_nonexistent_validator() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add three new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Carl is tombstoned next
+        let update_ctx = ctx.branch();
+        let tombs = vec!["carl".to_string()];
+        let (evt, msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &tombs,
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("tombstoned", "carl"),]);
+
+        // Check that no slashing message is emitted
+        assert_eq!(msgs.len(), 0);
+
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "carl".to_string(),
+                    state: State::Tombstoned {}
+                },
+            ]
+        );
+    }
 }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -2188,4 +2188,105 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn valset_update_updates_keep_state() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add two new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Bob is removed next
+        let update_ctx = ctx.branch();
+        let rems = vec!["bob".to_string()];
+        let (evt, _msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &rems,
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("removals", "bob"),]);
+
+        // Bob is updated next
+        let update_ctx = ctx.branch();
+        let upds = vec![AddValidator {
+            valoper: "bob".to_string(),
+            pub_key: "bob_pub_key_updated".to_string(),
+            }
+        ];
+        let (evt, _msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &upds,
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("updated", "bob"),]);
+
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        // Check that bob is still unbonded
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Unbonded {}
+                },
+            ]
+        );
+    }
 }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1895,6 +1895,7 @@ mod tests {
             ]
         );
     }
+
     #[test]
     fn valset_update_jailing_slashes() {
         let mut deps = mock_dependencies();
@@ -2005,6 +2006,84 @@ mod tests {
                 ValidatorState {
                     validator: "bob".to_string(),
                     state: State::Jailed {}
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn valset_update_removal_works() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add three new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Bob is removed next
+        let update_ctx = ctx.branch();
+        let rems = vec!["bob".to_string()];
+        let (evt, msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &rems,
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("removals", "bob"),]);
+
+        // Check there's no slashing message
+        assert_eq!(msgs.len(), 0);
+
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Unbonded {}
                 },
             ]
         );

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -867,7 +867,7 @@ impl ExternalStakingContract<'_> {
             stake
                 .points_alignment
                 .stake_decreased(stake_slash, distribution.points_per_stake);
-            distribution.total_stake -= stake_slash;
+            distribution.total_stake = distribution.total_stake.saturating_sub(stake_slash); // Don't fail if pending bond tx
             self.distribution.save(storage, validator, &distribution)?;
 
             // Slash the unbondings

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1377,7 +1377,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, tombstone one and check slashing
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -1492,7 +1492,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and tombstone one with a pending bond
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -1606,7 +1606,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and tombstone one with a pending unbond
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -1650,7 +1650,7 @@ mod tests {
                 to_binary(&ReceiveVirtualStake {
                     validator: "bob".to_string(),
                 })
-                    .unwrap(),
+                .unwrap(),
             )
             .unwrap();
         // Commit stake
@@ -1665,11 +1665,7 @@ mod tests {
             info: owner_info,
         };
         contract
-            .unstake(
-                stake_ctx,
-                "bob".to_string(),
-                coin(50, "uosmo"),
-            )
+            .unstake(stake_ctx, "bob".to_string(), coin(50, "uosmo"))
             .unwrap();
         // Unstake tx is pending
 
@@ -1706,7 +1702,7 @@ mod tests {
                         slash: Uint128::new(10), // Owner is slashed over the full stake, including pending
                     }],
                 })
-                    .unwrap(),
+                .unwrap(),
                 funds: vec![],
             }
         );
@@ -1738,7 +1734,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and tombstone one unbonded one
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -1819,7 +1815,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and tombstone no-one
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -1901,7 +1897,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and jail/unjail one
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -2001,7 +1997,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and jail one
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -2045,7 +2041,7 @@ mod tests {
                 to_binary(&ReceiveVirtualStake {
                     validator: "bob".to_string(),
                 })
-                    .unwrap(),
+                .unwrap(),
             )
             .unwrap();
         // Commit stake
@@ -2084,7 +2080,7 @@ mod tests {
                         slash: Uint128::new(10),
                     }],
                 })
-                    .unwrap(),
+                .unwrap(),
                 funds: vec![],
             }
         );
@@ -2116,7 +2112,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add three new validators, and tombstone one
+        // We add two new validators, and remove one
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -2194,7 +2190,7 @@ mod tests {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
-        // We add two new validators, and tombstone one
+        // We add two new validators, and remove/update one
         let adds = vec![
             AddValidator {
                 valoper: "alice".to_string(),
@@ -2247,14 +2243,13 @@ mod tests {
         let upds = vec![AddValidator {
             valoper: "bob".to_string(),
             pub_key: "bob_pub_key_updated".to_string(),
-            }
-        ];
+        }];
         let (evt, _msgs) = contract
             .valset_update(
                 update_ctx.deps,
                 update_ctx.env,
-                200,
-                2345,
+                300,
+                3456,
                 &[],
                 &[],
                 &upds,

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1480,4 +1480,118 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn valset_update_tombstoning_slashes_pending_bond() {
+        let mut deps = mock_dependencies();
+        let (mut ctx, contract) = do_instantiate(deps.as_mut());
+
+        // We add three new validators, and tombstone one
+        let adds = vec![
+            AddValidator {
+                valoper: "alice".to_string(),
+                pub_key: "alice_pub_key".to_string(),
+            },
+            AddValidator {
+                valoper: "bob".to_string(),
+                pub_key: "bob_pub_key".to_string(),
+            },
+        ];
+
+        contract
+            .valset_update(
+                ctx.deps.branch(),
+                ctx.env.clone(),
+                100,
+                1234,
+                &adds,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        // Cross stake with bob
+        let mut stake_deps = ctx.deps.branch();
+        let vault_info = mock_info("vault_addr", &[]);
+        let stake_ctx = ExecCtx {
+            deps: stake_deps.branch(),
+            env: mock_env(),
+            info: vault_info,
+        };
+        contract
+            .receive_virtual_stake(
+                stake_ctx,
+                OWNER.to_string(),
+                coin(100, "uosmo"),
+                1,
+                to_binary(&ReceiveVirtualStake {
+                    validator: "bob".to_string(),
+                })
+                    .unwrap(),
+            )
+            .unwrap();
+        // Tx is pending
+
+        // Bob is tombstoned next
+        let update_ctx = ctx.branch();
+        let tombs = vec!["bob".to_string()];
+        let (evt, msgs) = contract
+            .valset_update(
+                update_ctx.deps,
+                update_ctx.env,
+                200,
+                2345,
+                &[],
+                &[],
+                &[],
+                &[],
+                &[],
+                &tombs,
+            )
+            .unwrap();
+
+        // Check the event
+        assert_eq!(evt.attributes, vec![Attribute::new("tombstoned", "bob"),]);
+
+        // Check the slashing message
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            msgs[0],
+            WasmMsg::Execute {
+                contract_addr: "vault_addr".to_string(),
+                msg: to_binary(&CrossSlash {
+                    slashes: vec![SlashInfo {
+                        user: OWNER.to_string(),
+                        slash: Uint128::new(10),
+                    }],
+                })
+                    .unwrap(),
+                funds: vec![],
+            }
+        );
+
+        let query_deps = ctx.deps;
+        let query_ctx = QueryCtx {
+            deps: query_deps.as_ref(),
+            env: mock_env(),
+        };
+
+        let vals = contract.list_validators(query_ctx, None, None).unwrap();
+        assert_eq!(
+            vals.validators,
+            vec![
+                ValidatorState {
+                    validator: "alice".to_string(),
+                    state: State::Active {}
+                },
+                ValidatorState {
+                    validator: "bob".to_string(),
+                    state: State::Tombstoned {}
+                },
+            ]
+        );
+    }
 }

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -419,6 +419,16 @@ mod tests {
 
         let active = crdt.list_active_validators(&storage, None, 10).unwrap();
         assert_eq!(active, vec!["alice".to_string(), "carl".to_string()]);
+
+        let validators = crdt.list_validators(&storage, None, 10).unwrap();
+        assert_eq!(
+            validators,
+            vec![
+                ("alice".to_string(), State::Active {}),
+                ("bob".to_string(), State::Tombstoned {}),
+                ("carl".to_string(), State::Active {}),
+            ]
+        );
     }
 
     // Like happy path, but we remove bob before he was ever added
@@ -442,6 +452,16 @@ mod tests {
 
         let active = crdt.list_active_validators(&storage, None, 10).unwrap();
         assert_eq!(active, vec!["alice".to_string(), "carl".to_string()]);
+
+        let validators = crdt.list_validators(&storage, None, 10).unwrap();
+        assert_eq!(
+            validators,
+            vec![
+                ("alice".to_string(), State::Active {}),
+                ("bob".to_string(), State::Tombstoned {}),
+                ("carl".to_string(), State::Active {}),
+            ]
+        );
     }
 
     // add and remove many validators, then iterate over them

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -352,9 +352,9 @@ impl<'a> CrdtState<'a> {
         valoper: &str,
         height: u64,
     ) -> StdResult<Option<ValState>> {
-        let state = self.validators.load(storage, valoper)?;
-        match state.query_at_height(height) {
-            Some(val_state) if val_state.state == State::Active {} => Ok(Some(val_state.clone())),
+        let state = self.validator_at_height(storage, valoper, height)?;
+        match state {
+            Some(val_state) if val_state.state == State::Active {} => Ok(Some(val_state)),
             Some(_) => Ok(None),
             None => Ok(None),
         }
@@ -366,9 +366,12 @@ impl<'a> CrdtState<'a> {
         valoper: &str,
         height: u64,
     ) -> StdResult<Option<ValState>> {
-        let state = self.validators.load(storage, valoper)?;
-        match state.query_at_height(height) {
-            Some(val_state) => Ok(Some(val_state.clone())),
+        let state = self.validators.may_load(storage, valoper)?;
+        match state {
+            Some(state) => match state.query_at_height(height) {
+                Some(val_state) => Ok(Some(val_state.clone())),
+                None => Ok(None),
+            },
             None => Ok(None),
         }
     }

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -106,9 +106,9 @@ impl<'a> CrdtState<'a> {
         Ok(())
     }
 
-    /// Remove a validator.
+    /// Tombstone a validator.
     /// In non-test code, this is called from `ibc_packet_receive`
-    pub fn remove_validator(
+    pub fn tombstone_validator(
         &self,
         storage: &mut dyn Storage,
         valoper: &str,
@@ -222,7 +222,7 @@ mod tests {
             .unwrap();
         crdt.add_validator(&mut storage, "carl", "carl_pub_key", 303, 3456)
             .unwrap();
-        crdt.remove_validator(&mut storage, "bob", 201, 2346)
+        crdt.tombstone_validator(&mut storage, "bob", 201, 2346)
             .unwrap();
 
         assert!(crdt.is_active_validator(&storage, "alice").unwrap());
@@ -239,7 +239,7 @@ mod tests {
         let mut storage = MemoryStorage::new();
         let crdt = CrdtState::new();
 
-        crdt.remove_validator(&mut storage, "bob", 199, 2344)
+        crdt.tombstone_validator(&mut storage, "bob", 199, 2344)
             .unwrap();
         crdt.add_validator(&mut storage, "alice", "pk_a", 123, 1234)
             .unwrap();
@@ -270,7 +270,7 @@ mod tests {
         }
         // in reverse order, so remove doesn't shift the indexes we will later read
         for i in [19, 17, 12, 11, 7, 4, 3] {
-            crdt.remove_validator(&mut storage, &validators[i], 200, 2345)
+            crdt.tombstone_validator(&mut storage, &validators[i], 200, 2345)
                 .unwrap();
             validators.remove(i);
         }

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -216,6 +216,7 @@ impl<'a> CrdtState<'a> {
     }
 
     /// Add an existing validator to the active set after jailing.
+    /// If the validator does not exist, it is tombstoned, or it is not in the `Jailed` state, it does nothing.
     /// In non-test code, this is called from `ibc_packet_receive`
     pub fn unjail_validator(
         &self,
@@ -224,8 +225,34 @@ impl<'a> CrdtState<'a> {
         height: u64,
         time: u64,
     ) -> Result<(), StdError> {
-        let _ = (storage, valoper, height, time);
-        todo!()
+        let mut validator_state = self
+            .validators
+            .may_load(storage, valoper)?
+            .unwrap_or_else(|| ValidatorState(vec![]));
+
+        // We just silently ignore it if does not exist, or tombstoned
+        if !validator_state.is_empty() && !validator_state.is_tombstoned() {
+            // Copy data from previous entry. This is not commutative anymore :-/
+            let old = self.validator_at_height(storage, valoper, height)?;
+            // Ignore if not previous entry at height (should not happen)
+            if old.is_none() {
+                return Ok(());
+            }
+            let old = old.unwrap();
+            // Ignore if not jailed
+            if old.state != (State::Jailed {}) {
+                return Ok(());
+            }
+            let val_state = ValState {
+                pub_key: old.pub_key,
+                start_height: height,
+                start_time: time,
+                state: State::Active {},
+            };
+            validator_state.insert_unique(val_state);
+            self.validators.save(storage, valoper, &validator_state)?;
+        }
+        Ok(())
     }
 
     /// Tombstone a validator.

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -233,7 +233,7 @@ impl<'a> CrdtState<'a> {
     }
 
     /// Add an existing validator to the active set after jailing.
-    /// If the validator does not exist, it is tombstoned, or it is not in the `Jailed` state, it does nothing.
+    /// If the validator does not exist, or it is tombstoned, it does nothing.
     /// In non-test code, this is called from `ibc_packet_receive`
     pub fn unjail_validator(
         &self,
@@ -256,10 +256,6 @@ impl<'a> CrdtState<'a> {
                 return Ok(());
             }
             let old = old.unwrap();
-            // Ignore if not jailed
-            if old.state != (State::Jailed {}) {
-                return Ok(());
-            }
             let val_state = ValState {
                 pub_key: old.pub_key,
                 start_height: height,

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -272,7 +272,7 @@ impl<'a> CrdtState<'a> {
         // We just silently ignore it if already tombstoned
         if !validator_state.is_tombstoned() {
             let val_state = ValState {
-                pub_key: "TODO".to_string(),
+                pub_key: "".to_string(), // FIXME? Keep pubkey
                 start_height: height,
                 start_time: time,
                 state: State::Tombstoned {},

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -180,6 +180,7 @@ impl<'a> CrdtState<'a> {
     }
 
     /// Remove a validator from the active set due to jailing.
+    /// If the validator does not exist, or it is tombstoned, it does nothing.
     /// In non-test code, this is called from `ibc_packet_receive`
     pub fn jail_validator(
         &self,
@@ -188,8 +189,30 @@ impl<'a> CrdtState<'a> {
         height: u64,
         time: u64,
     ) -> Result<(), StdError> {
-        let _ = (storage, valoper, height, time);
-        todo!()
+        let mut validator_state = self
+            .validators
+            .may_load(storage, valoper)?
+            .unwrap_or_else(|| ValidatorState(vec![]));
+
+        // We just silently ignore it if does not exist, or tombstoned
+        if !validator_state.is_empty() && !validator_state.is_tombstoned() {
+            // Copy data from previous entry. This is not commutative anymore :-/
+            let old = self.validator_at_height(storage, valoper, height)?;
+            // Ignore if not previous entry at height (should not happen)
+            if old.is_none() {
+                return Ok(());
+            }
+            let old = old.unwrap();
+            let val_state = ValState {
+                pub_key: old.pub_key,
+                start_height: height,
+                start_time: time,
+                state: State::Jailed {},
+            };
+            validator_state.insert_unique(val_state);
+            self.validators.save(storage, valoper, &validator_state)?;
+        }
+        Ok(())
     }
 
     /// Add an existing validator to the active set after jailing.

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -75,7 +75,7 @@ impl<'a> CrdtState<'a> {
         }
     }
 
-    /// Add / Update a validator.
+    /// Add a validator to the active set.
     /// In test code, this is called from `test_set_active_validator`.
     /// In non-test code, this is called from `ibc_packet_receive`
     pub fn add_validator(
@@ -104,6 +104,63 @@ impl<'a> CrdtState<'a> {
             self.validators.save(storage, valoper, &validator_state)?;
         }
         Ok(())
+    }
+
+    /// Update a validator.
+    /// In test code, this is called from `test_set_active_validator`.
+    /// In non-test code, this is called from `ibc_packet_receive`
+    pub fn update_validator(
+        &self,
+        storage: &mut dyn Storage,
+        valoper: &str,
+        pub_key: &str,
+        height: u64,
+        time: u64,
+    ) -> Result<(), StdError> {
+        let _ = (storage, valoper, pub_key, height, time);
+        todo!()
+    }
+
+    /// Remove a validator from the active set.
+    /// In test code, this is called from `test_set_active_validator`.
+    /// In non-test code, this is called from `ibc_packet_receive`
+    pub fn remove_validator(
+        &self,
+        storage: &mut dyn Storage,
+        valoper: &str,
+        height: u64,
+        time: u64,
+    ) -> Result<(), StdError> {
+        let _ = (storage, valoper, height, time);
+        todo!()
+    }
+
+    /// Remove a validator from the active set due to jailing.
+    /// In test code, this is called from `test_set_active_validator`.
+    /// In non-test code, this is called from `ibc_packet_receive`
+    pub fn jail_validator(
+        &self,
+        storage: &mut dyn Storage,
+        valoper: &str,
+        height: u64,
+        time: u64,
+    ) -> Result<(), StdError> {
+        let _ = (storage, valoper, height, time);
+        todo!()
+    }
+
+    /// Add an existing validator to the active set after jailing.
+    /// In test code, this is called from `test_set_active_validator`.
+    /// In non-test code, this is called from `ibc_packet_receive`
+    pub fn unjail_validator(
+        &self,
+        storage: &mut dyn Storage,
+        valoper: &str,
+        height: u64,
+        time: u64,
+    ) -> Result<(), StdError> {
+        let _ = (storage, valoper, height, time);
+        todo!()
     }
 
     /// Tombstone a validator.

--- a/contracts/provider/external-staking/src/crdt.rs
+++ b/contracts/provider/external-staking/src/crdt.rs
@@ -338,11 +338,11 @@ impl<'a> CrdtState<'a> {
         storage: &dyn Storage,
         valoper: &str,
     ) -> StdResult<Option<ValState>> {
-        let state = self.validators.load(storage, valoper)?;
-        if state.is_active() {
-            Ok(state.0.first().cloned())
-        } else {
-            Ok(None)
+        let state = self.validators.may_load(storage, valoper)?;
+        match state {
+            Some(state) if state.is_active() => Ok(state.0.first().cloned()),
+            Some(_) => Ok(None),
+            None => Ok(None),
         }
     }
 

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -135,11 +135,23 @@ pub fn ibc_packet_receive(
             unjailed,
             tombstoned,
         } => {
-            let msgs = contract.valset_update(
-                deps, env, height, time, additions, removals, updated, jailed, unjailed, tombstoned,
+            let (evt, msgs) = contract.valset_update(
+                deps,
+                env,
+                height,
+                time,
+                &additions,
+                &removals,
+                &updated,
+                &jailed,
+                &unjailed,
+                &tombstoned,
             )?;
             let ack = ack_success(&ValsetUpdateAck {})?;
-            IbcReceiveResponse::new().set_ack(ack).add_messages(msgs)
+            IbcReceiveResponse::new()
+                .set_ack(ack)
+                .add_event(evt)
+                .add_messages(msgs)
         }
         ConsumerPacket::Distribute { validator, rewards } => {
             let evt = contract.distribute_rewards(deps, &validator, rewards)?;

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -8,9 +8,8 @@ use cosmwasm_std::{
 };
 use cw_storage_plus::Item;
 use mesh_apis::ibc::{
-    ack_success, validate_channel_order, AckWrapper, AddValidator, AddValidatorsAck,
-    ConsumerPacket, DistributeAck, JailValidatorsAck, ProtocolVersion, ProviderPacket,
-    RemoveValidator, RemoveValidatorsAck,
+    ack_success, validate_channel_order, AckWrapper, AddValidator, ConsumerPacket, DistributeAck,
+    ProtocolVersion, ProviderPacket, ValsetUpdateAck,
 };
 
 use crate::contract::ExternalStakingContract;
@@ -120,49 +119,34 @@ pub fn ibc_packet_receive(
     msg: IbcPacketReceiveMsg,
 ) -> Result<IbcReceiveResponse, ContractError> {
     // There is only one channel, so we don't need to switch.
-    // We also don't care about packet sequence as this is fully commutative.
+    // We also don't care about packet sequence as this is being ordered by height.
+    // If a validator is in more than one of the events, the end result will depend on the
+    // processing order below.
     let contract = ExternalStakingContract::new();
     let packet: ConsumerPacket = from_slice(&msg.packet.data)?;
     let resp = match packet {
-        ConsumerPacket::AddValidators(to_add) => {
-            for AddValidator {
-                valoper,
-                pub_key,
-                start_height,
-                start_time,
-            } in to_add
-            {
-                contract.val_set.add_validator(
-                    deps.storage,
-                    &valoper,
-                    &pub_key,
-                    start_height,
-                    start_time,
-                )?;
-            }
-            let ack = ack_success(&AddValidatorsAck {})?;
-            IbcReceiveResponse::new().set_ack(ack)
-        }
-        ConsumerPacket::TombstoneValidators(to_remove) => {
+        ConsumerPacket::ValsetUpdate {
+            height,
+            time,
+            additions,
+            removals,
+            updated,
+            jailed,
+            unjailed,
+            tombstoned,
+        } => {
             let mut msgs = vec![];
-            for RemoveValidator {
-                valoper,
-                height: end_height,
-                time: end_time,
-            } in to_remove
-            {
+            // Process tombstoning events first. Once tombstoned, a validator cannot be changed anymore.
+            for valoper in tombstoned {
                 // Check that the validator is active at height and slash it if that is the case
                 let active = contract.val_set.is_active_validator_at_height(
                     deps.storage,
                     &valoper,
-                    end_height,
+                    height,
                 )?;
-                contract.val_set.tombstone_validator(
-                    deps.storage,
-                    &valoper,
-                    end_height,
-                    end_time,
-                )?;
+                contract
+                    .val_set
+                    .tombstone_validator(deps.storage, &valoper, height, time)?;
                 if active {
                     // slash the validator
                     // TODO: Error handling / capturing
@@ -170,25 +154,39 @@ pub fn ibc_packet_receive(
                     msgs.push(msg);
                 }
             }
-            let ack = ack_success(&RemoveValidatorsAck {})?;
-            IbcReceiveResponse::new().set_ack(ack).add_messages(msgs)
-        }
-        ConsumerPacket::JailValidators(to_jail) => {
-            let mut msgs = vec![];
-            for RemoveValidator {
-                valoper,
-                height: end_height,
-                time: _end_time,
-            } in to_jail
-            {
+            // Process additions. Already existing validators will be ignored.
+            for AddValidator { valoper, pub_key } in additions {
+                contract
+                    .val_set
+                    .add_validator(deps.storage, &valoper, &pub_key, height, time)?;
+            }
+            // Process updates. Non-existent validators will be ignored.
+            for AddValidator { valoper, pub_key } in updated {
+                contract.val_set.update_validator(
+                    deps.storage,
+                    &valoper,
+                    &pub_key,
+                    height,
+                    time,
+                )?;
+            }
+            // Process removals. Non-existent validators will be ignored.
+            for valoper in removals {
+                contract
+                    .val_set
+                    .remove_validator(deps.storage, &valoper, height, time)?;
+            }
+            // Process jailings. Non-existent validators will be ignored.
+            for valoper in jailed {
                 // Check that the validator is active at height and slash it if that is the case
                 let active = contract.val_set.is_active_validator_at_height(
                     deps.storage,
                     &valoper,
-                    end_height,
+                    height,
                 )?;
-                // We don't change the validator's state here, as that's currently not supported
-                // (only Active and Tombstoned)
+                contract
+                    .val_set
+                    .jail_validator(deps.storage, &valoper, height, time)?;
                 if active {
                     // slash the validator
                     // TODO: Slash with a different slash ratio! (downtime / offline slash ratio)
@@ -196,7 +194,15 @@ pub fn ibc_packet_receive(
                     msgs.push(msg);
                 }
             }
-            let ack = ack_success(&JailValidatorsAck {})?;
+            // Process unjailings. Non-existent validators will be ignored.
+            // If the validator is in the jailed state, it will be set to active. Otherwise, it will
+            // be ignored.
+            for valoper in unjailed {
+                contract
+                    .val_set
+                    .unjail_validator(deps.storage, &valoper, height, time)?;
+            }
+            let ack = ack_success(&ValsetUpdateAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_messages(msgs)
         }
         ConsumerPacket::Distribute { validator, rewards } => {

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -157,9 +157,12 @@ pub fn ibc_packet_receive(
                     &valoper,
                     end_height,
                 )?;
-                contract
-                    .val_set
-                    .remove_validator(deps.storage, &valoper, end_height, end_time)?;
+                contract.val_set.tombstone_validator(
+                    deps.storage,
+                    &valoper,
+                    end_height,
+                    end_time,
+                )?;
                 if active {
                     // slash the validator
                     // TODO: Error handling / capturing

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{coin, Coin, IbcChannel};
 
+use crate::crdt::State;
 use crate::state::Stake;
 use crate::{error::ContractError, state::Config};
 
@@ -37,6 +38,17 @@ pub struct IbcChannelResponse {
 #[cw_serde]
 pub struct ListRemoteValidatorsResponse {
     pub validators: Vec<String>,
+}
+
+#[cw_serde]
+pub struct ListValidatorsResponse {
+    pub validators: Vec<ValidatorState>,
+}
+
+#[cw_serde]
+pub struct ValidatorState {
+    pub validator: String,
+    pub state: State,
 }
 
 /// Config information returned with query

--- a/contracts/provider/external-staking/src/msg.rs
+++ b/contracts/provider/external-staking/src/msg.rs
@@ -36,7 +36,7 @@ pub struct IbcChannelResponse {
 }
 
 #[cw_serde]
-pub struct ListRemoteValidatorsResponse {
+pub struct ListActiveValidatorsResponse {
     pub validators: Vec<String>,
 }
 

--- a/contracts/provider/external-staking/src/multitest/utils.rs
+++ b/contracts/provider/external-staking/src/multitest/utils.rs
@@ -81,7 +81,7 @@ impl ContractExt for Contract<'_> {
         for val in validators {
             let activate = AddValidator::mock(val);
             self.test_methods_proxy()
-                .test_set_active_validator(activate)
+                .test_set_active_validator(activate, 100, 1234)
                 .call("test")
                 .unwrap();
         }

--- a/contracts/provider/external-staking/src/test_methods.rs
+++ b/contracts/provider/external-staking/src/test_methods.rs
@@ -24,6 +24,8 @@ pub trait TestMethods {
         &self,
         ctx: ExecCtx,
         validator: AddValidator,
+        height: u64,
+        time: u64,
     ) -> Result<Response, Self::Error>;
 
     /// Commits a pending unstake.

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -184,8 +184,11 @@ impl TestMethods for ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(any(test, feature = "mt"))]
         {
-            let msg = self.handle_slashing(&ctx.env, ctx.deps.storage, &validator)?;
-            Ok(Response::new().add_message(msg))
+            let slash_msg = self.handle_slashing(&ctx.env, ctx.deps.storage, &validator)?;
+            match slash_msg {
+                Some(msg) => Ok(Response::new().add_message(msg)),
+                None => Ok(Response::new()),
+            }
         }
         #[cfg(not(any(test, feature = "mt")))]
         {

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -50,27 +50,19 @@ impl TestMethods for ExternalStakingContract<'_> {
         &self,
         ctx: ExecCtx,
         validator: AddValidator,
+        height: u64,
+        time: u64,
     ) -> Result<Response, ContractError> {
         #[cfg(any(feature = "mt", test))]
         {
-            let AddValidator {
-                valoper,
-                pub_key,
-                start_height,
-                start_time,
-            } = validator;
-            self.val_set.add_validator(
-                ctx.deps.storage,
-                &valoper,
-                &pub_key,
-                start_height,
-                start_time,
-            )?;
+            let AddValidator { valoper, pub_key } = validator;
+            self.val_set
+                .add_validator(ctx.deps.storage, &valoper, &pub_key, height, time)?;
             Ok(Response::new())
         }
         #[cfg(not(any(feature = "mt", test)))]
         {
-            let _ = (ctx, validator);
+            let _ = (ctx, validator, height, time);
             Err(ContractError::Unauthorized {})
         }
     }

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -59,13 +59,13 @@ impl TestMethods for ExternalStakingContract<'_> {
                 start_height,
                 start_time,
             } = validator;
-            let update = crate::crdt::ValUpdate {
-                pub_key,
+            self.val_set.add_validator(
+                ctx.deps.storage,
+                &valoper,
+                &pub_key,
                 start_height,
                 start_time,
-            };
-            self.val_set
-                .add_validator(ctx.deps.storage, &valoper, update)?;
+            )?;
             Ok(Response::new())
         }
         #[cfg(not(any(feature = "mt", test)))]

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -146,18 +146,16 @@ fn set_active_validators(
     cross_staking: &ExternalStakingContractProxy<MtApp>,
     validators: &[&str],
 ) -> (u64, u64) {
-    let mut update_valset_height = 0;
-    let mut update_valset_time = 0;
+    let update_valset_height = 100;
+    let update_valset_time = 1234;
 
     for validator in validators {
         let activate = AddValidator::mock(validator);
         cross_staking
             .test_methods_proxy()
-            .test_set_active_validator(activate.clone())
+            .test_set_active_validator(activate.clone(), update_valset_height, update_valset_time)
             .call("test")
             .unwrap();
-        update_valset_height = activate.start_height;
-        update_valset_time = activate.start_time;
     }
     (update_valset_height, update_valset_time)
 }

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -29,20 +29,18 @@ pub trait ConverterApi {
 
     /// Valset updates.
     ///
-    /// Only additions and permanent removals are accepted, as removals (leaving the active
-    /// validator set) are non-permanent and ignored on the Provider (CRDTs only support permanent
-    /// removals).
-    ///
-    /// If a validator that already exists in the list is re-sent for addition, its pubkey
-    /// will be updated.
     /// TODO: pubkeys need to be part of the Validator struct (requires CosmWasm support).
+    #[allow(clippy::too_many_arguments)]
     #[msg(exec)]
     fn valset_update(
         &self,
         ctx: ExecCtx,
         additions: Vec<Validator>,
-        tombstoned: Vec<String>,
+        removals: Vec<String>,
+        updated: Vec<Validator>,
         jailed: Vec<String>,
+        unjailed: Vec<String>,
+        tombstoned: Vec<String>,
     ) -> Result<Response, Self::Error>;
 }
 

--- a/packages/sync/src/locks.rs
+++ b/packages/sync/src/locks.rs
@@ -365,8 +365,8 @@ mod tests_plus {
         // We can range over them well
         let total_age = AGES
             .range(&store, None, None, cosmwasm_std::Order::Ascending)
-            .fold(Ok(Uint128::zero()), |sum, item| {
-                Ok::<_, TestsError>(sum? + *item?.1.read()?)
+            .try_fold(Uint128::zero(), |sum, item| {
+                Ok::<_, TestsError>(sum + *item?.1.read()?)
             })
             .unwrap();
         assert_eq!(total_age, Uint128::new(33 + 47 + 2));
@@ -395,8 +395,8 @@ mod tests_plus {
         // We can still range over all
         let total_age = AGES
             .range(&store, None, None, cosmwasm_std::Order::Ascending)
-            .fold(Ok(Uint128::zero()), |sum, item| {
-                Ok::<_, TestsError>(sum? + *item?.1.read()?)
+            .try_fold(Uint128::zero(), |sum, item| {
+                Ok::<_, TestsError>(sum + *item?.1.read()?)
             })
             .unwrap();
         assert_eq!(total_age, Uint128::new(33 + 47 + 2));
@@ -415,8 +415,8 @@ mod tests_plus {
         // We cannot range over all
         let err = AGES
             .range(&store, None, None, cosmwasm_std::Order::Ascending)
-            .fold(Ok(Uint128::zero()), |sum, item| {
-                Ok::<_, TestsError>(sum? + *item?.1.read()?)
+            .try_fold(Uint128::zero(), |sum, item| {
+                Ok::<_, TestsError>(sum + *item?.1.read()?)
             })
             .unwrap_err();
         assert_eq!(err, TestsError::Lock(LockError::WriteLocked));
@@ -478,8 +478,8 @@ mod tests_plus {
         // We can still range over all
         let total_collateral = USERS
             .range(&store, None, None, cosmwasm_std::Order::Ascending)
-            .fold(Ok(Uint128::zero()), |sum, item| {
-                Ok::<_, TestsError>(sum? + item?.1.read()?.collateral)
+            .try_fold(Uint128::zero(), |sum, item| {
+                Ok::<_, TestsError>(sum + item?.1.read()?.collateral)
             })
             .unwrap();
         assert_eq!(total_collateral, Uint128::new(1 + 4));
@@ -498,8 +498,8 @@ mod tests_plus {
         // We cannot range over all
         let err = USERS
             .range(&store, None, None, cosmwasm_std::Order::Ascending)
-            .fold(Ok(Uint128::zero()), |sum, item| {
-                Ok::<_, TestsError>(sum? + item?.1.read()?.max_lien)
+            .try_fold(Uint128::zero(), |sum, item| {
+                Ok::<_, TestsError>(sum + item?.1.read()?.max_lien)
             })
             .unwrap_err();
         assert_eq!(err, TestsError::Lock(LockError::WriteLocked));

--- a/packages/sync/src/range.rs
+++ b/packages/sync/src/range.rs
@@ -500,7 +500,7 @@ mod tests {
     #[test]
     fn invariants_over_set_of_liens() {
         // some existing outstanding liens
-        let liens = vec![
+        let liens = [
             ValueRange::new(Uint128::new(5000), Uint128::new(7000)),
             ValueRange::new(Uint128::new(2000), Uint128::new(8000)),
             ValueRange::new(Uint128::new(3000), Uint128::new(12000)),


### PR DESCRIPTION
Closes #118.

TODO:

- [x] `external-staking` tests. (done)
- [ ] ~~`virtual-staking` valset state updates~~. (to be done in a follow-up).