### PR TITLE
Virtual staking valset updates

### DIFF
--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -363,6 +363,7 @@ impl ConverterApi for ConverterContract<'_> {
         let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
 
         let mut event = Event::new("valset_update");
+        let mut is_empty = true;
 
         if !additions.is_empty() {
             event = event.add_attribute(
@@ -373,9 +374,11 @@ impl ConverterApi for ConverterContract<'_> {
                     .collect::<Vec<String>>()
                     .join(","),
             );
+            is_empty = false;
         }
         if !removals.is_empty() {
             event = event.add_attribute("removals", removals.join(","));
+            is_empty = false;
         }
         if !updated.is_empty() {
             event = event.add_attribute(
@@ -386,18 +389,22 @@ impl ConverterApi for ConverterContract<'_> {
                     .collect::<Vec<String>>()
                     .join(","),
             );
+            is_empty = false;
         }
         if !jailed.is_empty() {
             event = event.add_attribute("jailed", jailed.join(","));
+            is_empty = false;
         }
         if !unjailed.is_empty() {
             event = event.add_attribute("unjailed", unjailed.join(","));
+            is_empty = false;
         }
         if !tombstoned.is_empty() {
             event = event.add_attribute("tombstoned", tombstoned.join(","));
+            is_empty = false;
         }
         let mut resp = Response::new();
-        if !event.attributes.is_empty() {
+        if !is_empty {
             let valset_msg = valset_update_msg(
                 &ctx.env,
                 &channel,

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -39,11 +39,11 @@ pub struct VirtualStakingContract<'a> {
     // `bonded` could be a Map like `bond_requests`, but the only time we use it is to read / write the entire list in bulk (in handle_epoch),
     // never accessing one element. Reading 100 elements in an Item is much cheaper than ranging over a Map with 100 entries.
     pub bonded: Item<'a, Vec<(String, Uint128)>>,
-    /// This is what validators have been fully unbonded due to tombstoning
-    // The list will be cleared after processing in handle_epoch.
+    /// This is what validators have been requested to be slashed due to tombstoning.
+    // The list will be cleared after processing in `handle_epoch`.
     pub tombstone_requests: Item<'a, Vec<String>>,
-    /// This is what validators have been slashed due to jailing.
-    // The list will be cleared after processing in handle_epoch.
+    /// This is what validators have been requested to be slashed due to jailing.
+    // The list will be cleared after processing in `handle_epoch`.
     pub jail_requests: Item<'a, Vec<String>>,
 }
 

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -472,7 +472,7 @@ fn withdraw_reward_msgs<T: CustomQuery>(
     let inactive = inactive.iter().collect::<HashSet<_>>();
     let bonded = bonded
         .iter()
-        .filter(|(v, _)| !inactive.contains(v))
+        .filter(|(validator, amount)| !amount.is_zero() && !inactive.contains(validator))
         .collect::<Vec<_>>();
     // We need to make a list, so we know where to send the rewards later (reversed, so we can pop off the top)
     let targets = bonded

--- a/contracts/consumer/virtual-staking/src/multitest.rs
+++ b/contracts/consumer/virtual-staking/src/multitest.rs
@@ -65,7 +65,6 @@ fn setup<'a>(app: &'a App<MtApp>, args: SetupArgs<'a>) -> SetupResponse<'a> {
     }
 }
 
-// TODO: Redundant test. Remove it.
 #[test]
 fn instantiation() {
     let app = App::default();


### PR DESCRIPTION
Now closes #118.

Keeps a (simplified) list of `inactive` validators, to filter them out from the rewards gathering process.

No state keeping besides `bonded` and `inactive`, for simplicity. Can be extended to proper valset state keeping if / when needed.