### PR TITLE
Native slashing acct

### DIFF
--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -465,6 +465,7 @@ impl ExternalStakingContract<'_> {
         unjailed: &[String],
         tombstoned: &[String],
     ) -> Result<(Event, Vec<WasmMsg>), ContractError> {
+        let cfg = self.config.load(deps.storage)?;
         let mut msgs = vec![];
         let mut valopers: HashSet<String> = HashSet::new();
         // Process tombstoning events first. Once tombstoned, a validator cannot be changed anymore.
@@ -476,9 +477,14 @@ impl ExternalStakingContract<'_> {
             self.val_set
                 .tombstone_validator(deps.storage, valoper, height, time)?;
             if active {
-                // Slash the validator (if bonded)
-                let slash_msg =
-                    self.handle_slashing(&env, deps.storage, valoper, SlashingReason::DoubleSign)?;
+                // Slash the validator, if bonded
+                let slash_msg = self.handle_slashing(
+                    &env,
+                    deps.storage,
+                    &cfg,
+                    valoper,
+                    SlashingReason::DoubleSign,
+                )?;
                 if let Some(msg) = slash_msg {
                     msgs.push(msg)
                 }
@@ -511,9 +517,13 @@ impl ExternalStakingContract<'_> {
                 .jail_validator(deps.storage, valoper, height, time)?;
             if active {
                 // Slash the validator, if bonded
-                // TODO: Slash with a different slash ratio! (downtime / offline slash ratio)
-                let slash_msg =
-                    self.handle_slashing(&env, deps.storage, valoper, SlashingReason::Offline)?;
+                let slash_msg = self.handle_slashing(
+                    &env,
+                    deps.storage,
+                    &cfg,
+                    valoper,
+                    SlashingReason::Offline,
+                )?;
                 if let Some(msg) = slash_msg {
                     msgs.push(msg)
                 }
@@ -532,7 +542,6 @@ impl ExternalStakingContract<'_> {
             valopers.insert(valoper.clone());
         }
         // Maintenance. Drain events that are older than unbonding period from now
-        let cfg = self.config.load(deps.storage)?;
         // Assumes time keeping is the same in both chains
         let max_time = env
             .block
@@ -851,10 +860,10 @@ impl ExternalStakingContract<'_> {
         &self,
         env: &Env,
         storage: &mut dyn Storage,
+        config: &Config,
         validator: &str,
         reason: SlashingReason,
     ) -> Result<Option<WasmMsg>, ContractError> {
-        let config = self.config.load(storage)?;
         let slash_ratio = match reason {
             SlashingReason::Offline => config.slash_ratio.offline,
             SlashingReason::DoubleSign => config.slash_ratio.double_sign,

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1437,7 +1437,7 @@ mod tests {
     use mesh_apis::vault_api::VaultApiExecMsg::CrossSlash;
 
     static OSMO: &str = "uosmo";
-    static CREATOR: &str = "staking"; // The creator of the proxy contract(s) is the staking contract
+    static CREATOR: &str = "creator";
     static OWNER: &str = "user";
 
     fn do_instantiate(deps: DepsMut) -> (ExecCtx, ExternalStakingContract) {
@@ -1445,7 +1445,7 @@ mod tests {
         let mut ctx = InstantiateCtx {
             deps,
             env: mock_env(),
-            info: mock_info(CREATOR, &[coin(100, OSMO)]),
+            info: mock_info(CREATOR, &[]),
         };
         contract
             .instantiate(

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -893,6 +893,9 @@ impl ExternalStakingContract<'_> {
             // Calculating slashing with always the `high` value of the range goes against the user
             // in some scenario (pending stakes while slashing); but the scenario is relatively
             // unlikely.
+            if stake_high.is_zero() {
+                continue;
+            }
             let stake_slash = stake_high * slash_ratio;
             // Requires proper saturating methods in commit/rollback_stake/unstake
             stake.stake = ValueRange::new(
@@ -920,6 +923,9 @@ impl ExternalStakingContract<'_> {
                 user: user.to_string(),
                 slash: stake_slash + pending_slashed,
             });
+        }
+        if slash_infos.is_empty() {
+            return Ok(None);
         }
 
         // Route associated users to vault for slashing of their collateral

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -228,9 +228,11 @@ impl TestMethods for ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(any(test, feature = "mt"))]
         {
+            let cfg = self.config.load(ctx.deps.storage)?;
             let slash_msg = self.handle_slashing(
                 &ctx.env,
                 ctx.deps.storage,
+                &cfg,
                 &validator,
                 crate::contract::SlashingReason::DoubleSign,
             )?;

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -1,4 +1,7 @@
-use cosmwasm_std::{from_slice, Addr, Decimal, DepsMut, Reply, Response, SubMsgResponse};
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+use cosmwasm_std::{from_slice, Addr, Decimal, DepsMut, Env, Reply, Response, SubMsgResponse};
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
 use cw_utils::parse_instantiate_response_data;
@@ -6,6 +9,7 @@ use sylvia::types::{InstantiateCtx, QueryCtx, ReplyCtx};
 use sylvia::{contract, schemars};
 
 use mesh_apis::local_staking_api;
+use mesh_apis::local_staking_api::SudoMsg;
 use mesh_native_staking_proxy::msg::OwnerMsg;
 use mesh_native_staking_proxy::native_staking_callback;
 
@@ -66,6 +70,20 @@ impl NativeStakingContract<'_> {
         Ok(Response::new())
     }
 
+    /**
+     * This is called every time there's a change of the active validator set that implies slashing.
+     *
+     */
+    fn handle_jailing(
+        &self,
+        deps: DepsMut,
+        jailed: &[String],
+        tombstoned: &[String],
+    ) -> Result<Response, ContractError> {
+        let _ = (deps, jailed, tombstoned);
+        todo!()
+    }
+
     #[msg(query)]
     fn config(&self, ctx: QueryCtx) -> Result<ConfigResponse, ContractError> {
         self.config.load(ctx.deps.storage).map_err(Into::into)
@@ -123,5 +141,16 @@ impl NativeStakingContract<'_> {
         Ok(OwnerByProxyResponse {
             owner: owner_addr.to_string(),
         })
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn sudo(deps: DepsMut, _env: Env, msg: SudoMsg) -> Result<Response, ContractError> {
+    match msg {
+        SudoMsg::Jailing { jailed, tombstoned } => NativeStakingContract::new().handle_jailing(
+            deps,
+            &jailed.unwrap_or_default(),
+            &tombstoned.unwrap_or_default(),
+        ),
     }
 }

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -10,6 +10,7 @@ use sylvia::{contract, schemars};
 
 use mesh_apis::local_staking_api;
 use mesh_apis::local_staking_api::SudoMsg;
+use mesh_apis::vault_api::VaultApiHelper;
 use mesh_native_staking_proxy::msg::OwnerMsg;
 use mesh_native_staking_proxy::native_staking_callback;
 
@@ -65,7 +66,7 @@ impl NativeStakingContract<'_> {
         let config = Config {
             denom,
             proxy_code_id,
-            vault: ctx.info.sender,
+            vault: VaultApiHelper(ctx.info.sender),
             slash_ratio_dsign,
             slash_ratio_offline,
         };

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -84,7 +84,7 @@ impl NativeStakingContract<'_> {
      */
     fn handle_jailing(
         &self,
-        deps: DepsMut,
+        mut deps: DepsMut,
         jailed: &[String],
         tombstoned: &[String],
     ) -> Result<Response, ContractError> {
@@ -92,7 +92,7 @@ impl NativeStakingContract<'_> {
         let mut msgs = vec![];
         for validator in tombstoned {
             // Slash the validator (if bonded)
-            let slash_msg = self.handle_slashing(&deps, &cfg, validator)?;
+            let slash_msg = self.handle_slashing(&mut deps, &cfg, validator)?;
             if let Some(msg) = slash_msg {
                 msgs.push(msg)
             }
@@ -100,7 +100,7 @@ impl NativeStakingContract<'_> {
         for validator in jailed {
             // Slash the validator (if bonded)
             // TODO: Slash with a different slash ratio! (downtime / offline slash ratio)
-            let slash_msg = self.handle_slashing(&deps, &cfg, validator)?;
+            let slash_msg = self.handle_slashing(&mut deps, &cfg, validator)?;
             if let Some(msg) = slash_msg {
                 msgs.push(msg)
             }
@@ -110,7 +110,7 @@ impl NativeStakingContract<'_> {
 
     fn handle_slashing(
         &self,
-        deps: &DepsMut,
+        deps: &mut DepsMut,
         config: &Config,
         validator: &str,
     ) -> Result<Option<WasmMsg>, ContractError> {
@@ -125,9 +125,9 @@ impl NativeStakingContract<'_> {
         }
 
         let mut slash_infos = vec![];
-        for (owner, _) in owners {
+        for (owner, _) in &owners {
             // Get owner proxy address
-            let proxy = self.proxy_by_owner.load(deps.storage, &owner)?;
+            let proxy = self.proxy_by_owner.load(deps.storage, owner)?;
             // Get proxy's delegation (pre-slashing?) amount over validator
             // TODO: Confirm queried delegation amounts are pre- or post-slashing
             let delegation = deps
@@ -136,12 +136,22 @@ impl NativeStakingContract<'_> {
                 .map(|full_delegation| full_delegation.amount.amount)
                 .unwrap_or_default();
 
+            if delegation.is_zero() {
+                // Maintenance: Remove delegator from map in passing
+                // TODO: Remove zero amount delegations from delegators map periodically
+                self.delegators.remove(deps.storage, (validator, owner));
+                continue;
+            }
+
             let slash_amount = delegation * config.max_slashing;
 
             slash_infos.push(SlashInfo {
                 user: owner.to_string(),
                 slash: slash_amount,
             });
+        }
+        if slash_infos.is_empty() {
+            return Ok(None);
         }
         // Route associated users to vault for slashing of their collateral
         let msg = config

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -3,7 +3,8 @@ use cosmwasm_std::entry_point;
 
 use cosmwasm_std::Order::Ascending;
 use cosmwasm_std::{
-    from_slice, Addr, Decimal, DepsMut, Env, Reply, Response, StdResult, SubMsgResponse, WasmMsg,
+    from_slice, Addr, Decimal, DepsMut, Env, Event, Reply, Response, StdResult, SubMsgResponse,
+    WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
@@ -105,7 +106,14 @@ impl NativeStakingContract<'_> {
                 msgs.push(msg)
             }
         }
-        Ok(Response::new().add_messages(msgs))
+        let mut evt = Event::new("jailing");
+        if !jailed.is_empty() {
+            evt = evt.add_attribute("jailed", jailed.join(","));
+        }
+        if !tombstoned.is_empty() {
+            evt = evt.add_attribute("tombstoned", tombstoned.join(","));
+        }
+        Ok(Response::new().add_event(evt).add_messages(msgs))
     }
 
     fn handle_slashing(

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -1,7 +1,10 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
-use cosmwasm_std::{from_slice, Addr, Decimal, DepsMut, Env, Reply, Response, SubMsgResponse};
+use cosmwasm_std::Order::Ascending;
+use cosmwasm_std::{
+    from_slice, Addr, Decimal, DepsMut, Env, Reply, Response, StdResult, SubMsgResponse, WasmMsg,
+};
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
 use cw_utils::parse_instantiate_response_data;
@@ -10,7 +13,7 @@ use sylvia::{contract, schemars};
 
 use mesh_apis::local_staking_api;
 use mesh_apis::local_staking_api::SudoMsg;
-use mesh_apis::vault_api::VaultApiHelper;
+use mesh_apis::vault_api::{SlashInfo, VaultApiHelper};
 use mesh_native_staking_proxy::msg::OwnerMsg;
 use mesh_native_staking_proxy::native_staking_callback;
 
@@ -85,8 +88,66 @@ impl NativeStakingContract<'_> {
         jailed: &[String],
         tombstoned: &[String],
     ) -> Result<Response, ContractError> {
-        let _ = (deps, jailed, tombstoned);
-        todo!()
+        let cfg = self.config.load(deps.storage)?;
+        let mut msgs = vec![];
+        for validator in tombstoned {
+            // Slash the validator (if bonded)
+            let slash_msg = self.handle_slashing(&deps, &cfg, validator)?;
+            if let Some(msg) = slash_msg {
+                msgs.push(msg)
+            }
+        }
+        for validator in jailed {
+            // Slash the validator (if bonded)
+            // TODO: Slash with a different slash ratio! (downtime / offline slash ratio)
+            let slash_msg = self.handle_slashing(&deps, &cfg, validator)?;
+            if let Some(msg) = slash_msg {
+                msgs.push(msg)
+            }
+        }
+        Ok(Response::new().add_messages(msgs))
+    }
+
+    fn handle_slashing(
+        &self,
+        deps: &DepsMut,
+        config: &Config,
+        validator: &str,
+    ) -> Result<Option<WasmMsg>, ContractError> {
+        // Get all mesh delegators to this validator
+        let owners = self
+            .delegators
+            .prefix(validator)
+            .range(deps.storage, None, None, Ascending)
+            .collect::<StdResult<Vec<_>>>()?;
+        if owners.is_empty() {
+            return Ok(None);
+        }
+
+        let mut slash_infos = vec![];
+        for (owner, _) in owners {
+            // Get owner proxy address
+            let proxy = self.proxy_by_owner.load(deps.storage, &owner)?;
+            // Get proxy's delegation (pre-slashing?) amount over validator
+            // TODO: Confirm queried delegation amounts are pre- or post-slashing
+            let delegation = deps
+                .querier
+                .query_delegation(proxy, validator)?
+                .map(|full_delegation| full_delegation.amount.amount)
+                .unwrap_or_default();
+
+            let slash_amount = delegation * config.max_slashing;
+
+            slash_infos.push(SlashInfo {
+                user: owner.to_string(),
+                slash: slash_amount,
+            });
+        }
+        // Route associated users to vault for slashing of their collateral
+        let msg = config
+            .vault
+            .process_local_slashing(slash_infos, validator)?;
+        Ok(Some(msg))
     }
 
     #[msg(query)]

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -28,6 +28,9 @@ pub struct NativeStakingContract<'a> {
     pub proxy_by_owner: Map<'a, &'a Addr, Addr>,
     /// Reverse map of owner address by proxy contract address
     pub owner_by_proxy: Map<'a, &'a Addr, Addr>,
+    /// Map of delegators per validator
+    // This is used for prefixing and ranging during slashing
+    pub delegators: Map<'a, (&'a str, &'a Addr), bool>,
 }
 
 #[cfg_attr(not(feature = "library"), sylvia::entry_points)]
@@ -41,6 +44,7 @@ impl NativeStakingContract<'_> {
             config: Item::new("config"),
             proxy_by_owner: Map::new("proxies"),
             owner_by_proxy: Map::new("owners"),
+            delegators: Map::new("delegators"),
         }
     }
 

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -41,6 +41,10 @@ impl LocalStakingApi for NativeStakingContract<'_> {
 
         let owner_addr = ctx.deps.api.addr_validate(&owner)?;
 
+        // Add it to the delegators map
+        self.delegators
+            .save(ctx.deps.storage, (&validator, &owner_addr), &true)?;
+
         // Look up if there is a proxy to match. Instantiate or call stake on existing
         match self
             .proxy_by_owner

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -31,7 +31,7 @@ impl LocalStakingApi for NativeStakingContract<'_> {
     ) -> Result<Response, Self::Error> {
         // Can only be called by the vault
         let cfg = self.config.load(ctx.deps.storage)?;
-        ensure_eq!(cfg.vault, ctx.info.sender, ContractError::Unauthorized {});
+        ensure_eq!(cfg.vault.0, ctx.info.sender, ContractError::Unauthorized {});
 
         // Assert funds are passed in
         let _paid = must_pay(&ctx.info, &cfg.denom)?;
@@ -95,7 +95,7 @@ impl LocalStakingApi for NativeStakingContract<'_> {
     ) -> Result<Response, Self::Error> {
         // Can only be called by the vault
         let cfg = self.config.load(ctx.deps.storage)?;
-        ensure_eq!(cfg.vault, ctx.info.sender, ContractError::Unauthorized {});
+        ensure_eq!(cfg.vault.0, ctx.info.sender, ContractError::Unauthorized {});
         // Assert no funds are passed in
         nonpayable(&ctx.info)?;
 

--- a/contracts/provider/native-staking/src/native_staking_callback.rs
+++ b/contracts/provider/native-staking/src/native_staking_callback.rs
@@ -3,7 +3,6 @@ use cw_utils::must_pay;
 use sylvia::contract;
 use sylvia::types::ExecCtx;
 
-use mesh_apis::vault_api::VaultApiHelper;
 #[allow(unused_imports)]
 use mesh_native_staking_proxy::native_staking_callback::{self, NativeStakingCallback};
 
@@ -35,7 +34,8 @@ impl NativeStakingCallback for NativeStakingContract<'_> {
             .load(ctx.deps.storage, &ctx.info.sender)?;
 
         // Send the tokens to the vault contract
-        let msg = VaultApiHelper(cfg.vault)
+        let msg = cfg
+            .vault
             .release_local_stake(owner_addr.to_string(), ctx.info.funds)?;
 
         Ok(Response::new().add_message(msg))

--- a/contracts/provider/native-staking/src/state.rs
+++ b/contracts/provider/native-staking/src/state.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Decimal};
+use cosmwasm_std::Decimal;
+use mesh_apis::vault_api::VaultApiHelper;
 
 #[cw_serde]
 pub struct Config {
@@ -10,7 +11,7 @@ pub struct Config {
     pub proxy_code_id: u64,
 
     /// The address of the vault contract (where we get and return stake)
-    pub vault: Addr,
+    pub vault: VaultApiHelper,
 
     /// The slash ratio for double signing
     pub slash_ratio_dsign: Decimal,

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -970,6 +970,35 @@ impl VaultApi for VaultContract<'_> {
         Ok(resp)
     }
 
+    /// This must be called by the native staking contract to process a misbehaviour
+    #[msg(exec)]
+    fn local_slash(
+        &self,
+        mut ctx: ExecCtx,
+        slashes: Vec<SlashInfo>,
+        validator: String,
+    ) -> Result<Response, Self::Error> {
+        nonpayable(&ctx.info)?;
+
+        let msgs = self.slash(&mut ctx, &slashes, &validator)?;
+
+        let resp = Response::new()
+            .add_messages(msgs)
+            .add_attribute("action", "local_slash")
+            .add_attribute("lien_holder", ctx.info.sender)
+            .add_attribute("validator", validator.to_string())
+            .add_attribute(
+                "users",
+                slashes
+                    .iter()
+                    .map(|s| s.user.clone())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+
+        Ok(resp)
+    }
+
     /// This must be called by the external staking contract to process a misbehaviour
     #[msg(exec)]
     fn cross_slash(
@@ -984,7 +1013,7 @@ impl VaultApi for VaultContract<'_> {
 
         let resp = Response::new()
             .add_messages(msgs)
-            .add_attribute("action", "process_cross_slashing")
+            .add_attribute("action", "cross_slash")
             .add_attribute("lien_holder", ctx.info.sender)
             .add_attribute("validator", validator.to_string())
             .add_attribute(

--- a/packages/apis/src/local_staking_api.rs
+++ b/packages/apis/src/local_staking_api.rs
@@ -99,3 +99,15 @@ impl LocalStakingApiHelper {
         deps.querier.query_wasm_smart(&self.0, &query)
     }
 }
+
+#[cw_serde]
+pub enum SudoMsg {
+    /// `SudoMsg::Jailing` should be called every time there's a validator set update that implies
+    /// slashing.
+    ///  - Temporary removal of a validator from the active set due to jailing.
+    ///  - Permanent removal (i.e. tombstoning) of a validator from the active set.
+    Jailing {
+        jailed: Option<Vec<String>>,
+        tombstoned: Option<Vec<String>>,
+    },
+}


### PR DESCRIPTION
Closes #129.

Proposed jailing API is tentative and can be changed / adjusted if needed.

Pre- vs. post-slashing behaviour of the delegated amounts (at the moment of the jailing handler call) must be established / defined based on on-chain checks, and / or analysis.

TODO:

- [x] Tests.