### PR TITLE
support multiple slash ratios

### DIFF
--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -60,7 +60,7 @@ impl Default for ExternalStakingContract<'_> {
     }
 }
 
-enum SlashingReason {
+pub(crate) enum SlashingReason {
     Offline,
     DoubleSign,
 }
@@ -1449,6 +1449,7 @@ mod tests {
                     connection_id: "connection_id_1".to_string(),
                     port_id: "port_id_1".to_string(),
                 },
+                Decimal::percent(10),
                 Decimal::percent(10),
             )
             .unwrap();

--- a/contracts/provider/external-staking/src/error.rs
+++ b/contracts/provider/external-staking/src/error.rs
@@ -24,8 +24,8 @@ pub enum ContractError {
     #[error("Invalid denom, {0} expected")]
     InvalidDenom(String),
 
-    #[error("You cannot use a max slashing rate over 1.0 (100%)")]
-    InvalidMaxSlashing,
+    #[error("You cannot specify a slash ratio over 1.0 (100%)")]
+    InvalidSlashRatio,
 
     #[error("Not enough tokens staked, up to {0} can be unbond")]
     NotEnoughStake(Uint128),

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -31,7 +31,8 @@ const STAR: &str = "star";
 /// 10% slashing on the remote chain
 const SLASHING_PERCENTAGE: u64 = 10;
 /// 5% slashing on the local chain (so we can differentiate in future tests)
-const LOCAL_SLASHING_PERCENTAGE: u64 = 5;
+const LOCAL_SLASHING_PERCENTAGE_DSIGN: u64 = 5;
+const LOCAL_SLASHING_PERCENTAGE_OFFLINE: u64 = 5;
 
 // Shortcut setuping all needed contracts
 //
@@ -52,7 +53,8 @@ fn setup<'app>(
     let native_staking_instantiate = NativeStakingInstantiateMsg {
         denom: OSMO.to_owned(),
         proxy_code_id: native_staking_proxy_code.code_id(),
-        max_slashing: Decimal::percent(LOCAL_SLASHING_PERCENTAGE),
+        max_slashing_dsign: Decimal::percent(LOCAL_SLASHING_PERCENTAGE_DSIGN),
+        max_slashing_offline: Decimal::percent(LOCAL_SLASHING_PERCENTAGE_OFFLINE),
     };
 
     let staking_init = StakingInitInfo {
@@ -75,6 +77,7 @@ fn setup<'app>(
             vault.contract_addr.to_string(),
             unbond_period,
             remote_contact,
+            Decimal::percent(SLASHING_PERCENTAGE),
             Decimal::percent(SLASHING_PERCENTAGE),
         )
         .call(owner)?;

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -18,7 +18,7 @@ use crate::contract::cross_staking::test_utils::CrossStakingApi;
 use crate::contract::multitest_utils::{CodeId, ExternalStakingContractProxy};
 use crate::error::ContractError;
 use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo, ValidatorPendingRewards};
-use crate::state::Stake;
+use crate::state::{MaxSlashing, Stake};
 use crate::test_methods_impl::test_utils::TestMethods;
 use utils::{
     assert_rewards, get_last_external_staking_pending_tx_id, AppExt as _, ContractExt as _,
@@ -77,8 +77,10 @@ fn setup<'app>(
             vault.contract_addr.to_string(),
             unbond_period,
             remote_contact,
-            Decimal::percent(SLASHING_PERCENTAGE),
-            Decimal::percent(SLASHING_PERCENTAGE),
+            MaxSlashing {
+                double_sign: Decimal::percent(SLASHING_PERCENTAGE),
+                offline: Decimal::percent(SLASHING_PERCENTAGE),
+            },
         )
         .call(owner)?;
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -18,7 +18,7 @@ use crate::contract::cross_staking::test_utils::CrossStakingApi;
 use crate::contract::multitest_utils::{CodeId, ExternalStakingContractProxy};
 use crate::error::ContractError;
 use crate::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo, ValidatorPendingRewards};
-use crate::state::{MaxSlashing, Stake};
+use crate::state::{SlashRatio, Stake};
 use crate::test_methods_impl::test_utils::TestMethods;
 use utils::{
     assert_rewards, get_last_external_staking_pending_tx_id, AppExt as _, ContractExt as _,
@@ -53,8 +53,8 @@ fn setup<'app>(
     let native_staking_instantiate = NativeStakingInstantiateMsg {
         denom: OSMO.to_owned(),
         proxy_code_id: native_staking_proxy_code.code_id(),
-        max_slashing_dsign: Decimal::percent(LOCAL_SLASHING_PERCENTAGE_DSIGN),
-        max_slashing_offline: Decimal::percent(LOCAL_SLASHING_PERCENTAGE_OFFLINE),
+        slash_ratio_dsign: Decimal::percent(LOCAL_SLASHING_PERCENTAGE_DSIGN),
+        slash_ratio_offline: Decimal::percent(LOCAL_SLASHING_PERCENTAGE_OFFLINE),
     };
 
     let staking_init = StakingInitInfo {
@@ -77,7 +77,7 @@ fn setup<'app>(
             vault.contract_addr.to_string(),
             unbond_period,
             remote_contact,
-            MaxSlashing {
+            SlashRatio {
                 double_sign: Decimal::percent(SLASHING_PERCENTAGE),
                 offline: Decimal::percent(SLASHING_PERCENTAGE),
             },
@@ -101,7 +101,7 @@ fn instantiate() {
 
     let max_slash = contract.cross_staking_api_proxy().max_slash().unwrap();
     assert_eq!(
-        max_slash.max_slash_dsign,
+        max_slash.slash_ratio_dsign,
         Decimal::percent(SLASHING_PERCENTAGE)
     );
 }

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -95,7 +95,10 @@ fn instantiate() {
     assert_eq!(stakes.stakes, []);
 
     let max_slash = contract.cross_staking_api_proxy().max_slash().unwrap();
-    assert_eq!(max_slash.max_slash, Decimal::percent(SLASHING_PERCENTAGE));
+    assert_eq!(
+        max_slash.max_slash_dsign,
+        Decimal::percent(SLASHING_PERCENTAGE)
+    );
 }
 
 #[test]

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -16,12 +16,12 @@ pub struct Config {
     pub vault: VaultApiHelper,
     /// Unbonding period for claims in seconds
     pub unbonding_period: u64,
-    /// Max slash percentage
-    pub max_slashing: MaxSlashing,
+    /// The slash ratio
+    pub slash_ratio: SlashRatio,
 }
 
 #[cw_serde]
-pub struct MaxSlashing {
+pub struct SlashRatio {
     pub double_sign: Decimal,
     pub offline: Decimal,
 }

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -16,10 +16,14 @@ pub struct Config {
     pub vault: VaultApiHelper,
     /// Unbonding period for claims in seconds
     pub unbonding_period: u64,
-    /// Max slash percentage for double signing
-    pub max_slashing_dsign: Decimal,
-    /// Max slash percentage for being offline
-    pub max_slashing_offline: Decimal,
+    /// Max slash percentage
+    pub max_slashing: MaxSlashing,
+}
+
+#[cw_serde]
+pub struct MaxSlashing {
+    pub double_sign: Decimal,
+    pub offline: Decimal,
 }
 
 /// All single stake related information - entry per `(user, validator)` pair, including

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -16,8 +16,10 @@ pub struct Config {
     pub vault: VaultApiHelper,
     /// Unbonding period for claims in seconds
     pub unbonding_period: u64,
-    /// Max slash percentage (from InstantiateMsg, maybe later from the chain)
-    pub max_slashing: Decimal,
+    /// Max slash percentage for double signing
+    pub max_slashing_dsign: Decimal,
+    /// Max slash percentage for being offline
+    pub max_slashing_offline: Decimal,
 }
 
 /// All single stake related information - entry per `(user, validator)` pair, including

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -228,7 +228,12 @@ impl TestMethods for ExternalStakingContract<'_> {
     ) -> Result<Response, ContractError> {
         #[cfg(any(test, feature = "mt"))]
         {
-            let slash_msg = self.handle_slashing(&ctx.env, ctx.deps.storage, &validator)?;
+            let slash_msg = self.handle_slashing(
+                &ctx.env,
+                ctx.deps.storage,
+                &validator,
+                crate::contract::SlashingReason::DoubleSign,
+            )?;
             match slash_msg {
                 Some(msg) => Ok(Response::new().add_message(msg)),
                 None => Ok(Response::new()),

--- a/contracts/provider/native-staking-proxy/src/multitest.rs
+++ b/contracts/provider/native-staking-proxy/src/multitest.rs
@@ -68,7 +68,8 @@ fn setup<'app>(
         msg: to_binary(&mesh_native_staking::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
-            max_slashing: Decimal::percent(5),
+            max_slashing_dsign: Decimal::percent(5),
+            max_slashing_offline: Decimal::percent(5),
         })
         .unwrap(),
         label: None,

--- a/contracts/provider/native-staking-proxy/src/multitest.rs
+++ b/contracts/provider/native-staking-proxy/src/multitest.rs
@@ -68,8 +68,8 @@ fn setup<'app>(
         msg: to_binary(&mesh_native_staking::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
-            max_slashing_dsign: Decimal::percent(5),
-            max_slashing_offline: Decimal::percent(5),
+            slash_ratio_dsign: Decimal::percent(5),
+            slash_ratio_offline: Decimal::percent(5),
         })
         .unwrap(),
         label: None,

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -47,19 +47,19 @@ impl NativeStakingContract<'_> {
         ctx: InstantiateCtx,
         denom: String,
         proxy_code_id: u64,
-        max_slashing_dsign: Decimal,
-        max_slashing_offline: Decimal,
+        slash_ratio_dsign: Decimal,
+        slash_ratio_offline: Decimal,
     ) -> Result<Response, ContractError> {
-        if max_slashing_dsign > Decimal::one() || max_slashing_offline > Decimal::one() {
-            return Err(ContractError::InvalidMaxSlashing);
+        if slash_ratio_dsign > Decimal::one() || slash_ratio_offline > Decimal::one() {
+            return Err(ContractError::InvalidSlashRatio);
         }
 
         let config = Config {
             denom,
             proxy_code_id,
             vault: ctx.info.sender,
-            max_slashing_dsign,
-            max_slashing_offline,
+            slash_ratio_dsign,
+            slash_ratio_offline,
         };
         self.config.save(ctx.deps.storage, &config)?;
         set_contract_version(ctx.deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -47,9 +47,10 @@ impl NativeStakingContract<'_> {
         ctx: InstantiateCtx,
         denom: String,
         proxy_code_id: u64,
-        max_slashing: Decimal,
+        max_slashing_dsign: Decimal,
+        max_slashing_offline: Decimal,
     ) -> Result<Response, ContractError> {
-        if max_slashing > Decimal::one() {
+        if max_slashing_dsign > Decimal::one() || max_slashing_offline > Decimal::one() {
             return Err(ContractError::InvalidMaxSlashing);
         }
 
@@ -57,7 +58,8 @@ impl NativeStakingContract<'_> {
             denom,
             proxy_code_id,
             vault: ctx.info.sender,
-            max_slashing,
+            max_slashing_dsign,
+            max_slashing_offline,
         };
         self.config.save(ctx.deps.storage, &config)?;
         set_contract_version(ctx.deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;

--- a/contracts/provider/native-staking/src/error.rs
+++ b/contracts/provider/native-staking/src/error.rs
@@ -25,6 +25,6 @@ pub enum ContractError {
     #[error("Missing proxy contract for {0}")]
     NoProxy(String),
 
-    #[error("You cannot use a max slashing rate over 1.0 (100%)")]
-    InvalidMaxSlashing,
+    #[error("You cannot specify a slash ratio over 1.0 (100%)")]
+    InvalidSlashRatio,
 }

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -4,7 +4,7 @@ use sylvia::types::QueryCtx;
 use sylvia::{contract, types::ExecCtx};
 
 #[allow(unused_imports)]
-use mesh_apis::local_staking_api::{self, LocalStakingApi, MaxSlashResponse};
+use mesh_apis::local_staking_api::{self, LocalStakingApi, SlashRatioResponse};
 
 use crate::contract::{NativeStakingContract, REPLY_ID_INSTANTIATE};
 use crate::error::ContractError;
@@ -121,15 +121,15 @@ impl LocalStakingApi for NativeStakingContract<'_> {
 
     /// Returns the maximum percentage that can be slashed
     #[msg(query)]
-    fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error> {
+    fn max_slash(&self, ctx: QueryCtx) -> Result<SlashRatioResponse, Self::Error> {
         let Config {
-            max_slashing_dsign,
-            max_slashing_offline,
+            slash_ratio_dsign,
+            slash_ratio_offline,
             ..
         } = self.config.load(ctx.deps.storage)?;
-        Ok(MaxSlashResponse {
-            max_slash_dsign: max_slashing_dsign,
-            max_slash_offline: max_slashing_offline,
+        Ok(SlashRatioResponse {
+            slash_ratio_dsign,
+            slash_ratio_offline,
         })
     }
 }

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -122,9 +122,14 @@ impl LocalStakingApi for NativeStakingContract<'_> {
     /// Returns the maximum percentage that can be slashed
     #[msg(query)]
     fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error> {
-        let Config { max_slashing, .. } = self.config.load(ctx.deps.storage)?;
+        let Config {
+            max_slashing_dsign,
+            max_slashing_offline,
+            ..
+        } = self.config.load(ctx.deps.storage)?;
         Ok(MaxSlashResponse {
-            max_slash: max_slashing,
+            max_slash_dsign: max_slashing_dsign,
+            max_slash_offline: max_slashing_offline,
         })
     }
 }

--- a/contracts/provider/native-staking/src/multitest.rs
+++ b/contracts/provider/native-staking/src/multitest.rs
@@ -19,10 +19,15 @@ use crate::msg::{OwnerByProxyResponse, ProxyByOwnerResponse};
 
 const OSMO: &str = "OSMO";
 
-const SLASHING_PERCENTAGE: u64 = 15;
+const SLASHING_PERCENTAGE_DSIGN: u64 = 15;
+const SLASHING_PERCENTAGE_OFFLINE: u64 = 10;
 
-fn slashing_rate() -> Decimal {
-    Decimal::percent(SLASHING_PERCENTAGE)
+fn slashing_rate_dsign() -> Decimal {
+    Decimal::percent(SLASHING_PERCENTAGE_DSIGN)
+}
+
+fn slashing_rate_offline() -> Decimal {
+    Decimal::percent(SLASHING_PERCENTAGE_OFFLINE)
 }
 
 fn app(balances: &[(&str, (u128, &str))], validators: &[&str]) -> App<MtApp> {
@@ -108,7 +113,8 @@ fn instantiation() {
         .instantiate(
             OSMO.to_owned(),
             staking_proxy_code.code_id(),
-            slashing_rate(),
+            slashing_rate_dsign(),
+            slashing_rate_offline(),
         )
         .with_label("Staking")
         .call(owner)
@@ -118,7 +124,7 @@ fn instantiation() {
     assert_eq!(config.denom, OSMO);
 
     let res = staking.local_staking_api_proxy().max_slash().unwrap();
-    assert_eq!(res.max_slash, slashing_rate());
+    assert_eq!(res.max_slash_dsign, slashing_rate_dsign());
 }
 
 #[test]
@@ -141,7 +147,8 @@ fn receiving_stake() {
         .instantiate(
             OSMO.to_owned(),
             staking_proxy_code.code_id(),
-            slashing_rate(),
+            slashing_rate_dsign(),
+            slashing_rate_offline(),
         )
         .with_label("Staking")
         .call(owner)
@@ -260,7 +267,8 @@ fn releasing_proxy_stake() {
         msg: to_binary(&crate::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
-            max_slashing: slashing_rate(),
+            max_slashing_dsign: slashing_rate_dsign(),
+            max_slashing_offline: slashing_rate_offline(),
         })
         .unwrap(),
         label: None,

--- a/contracts/provider/native-staking/src/multitest.rs
+++ b/contracts/provider/native-staking/src/multitest.rs
@@ -124,7 +124,7 @@ fn instantiation() {
     assert_eq!(config.denom, OSMO);
 
     let res = staking.local_staking_api_proxy().max_slash().unwrap();
-    assert_eq!(res.max_slash_dsign, slashing_rate_dsign());
+    assert_eq!(res.slash_ratio_dsign, slashing_rate_dsign());
 }
 
 #[test]
@@ -267,8 +267,8 @@ fn releasing_proxy_stake() {
         msg: to_binary(&crate::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
-            max_slashing_dsign: slashing_rate_dsign(),
-            max_slashing_offline: slashing_rate_offline(),
+            slash_ratio_dsign: slashing_rate_dsign(),
+            slash_ratio_offline: slashing_rate_offline(),
         })
         .unwrap(),
         label: None,

--- a/contracts/provider/native-staking/src/state.rs
+++ b/contracts/provider/native-staking/src/state.rs
@@ -12,9 +12,9 @@ pub struct Config {
     /// The address of the vault contract (where we get and return stake)
     pub vault: Addr,
 
-    /// Max slash percentage for double signing
-    pub max_slashing_dsign: Decimal,
+    /// The slash ratio for double signing
+    pub slash_ratio_dsign: Decimal,
 
-    /// max slash percentage for being offline
-    pub max_slashing_offline: Decimal,
+    /// The slash ratio for being offline
+    pub slash_ratio_offline: Decimal,
 }

--- a/contracts/provider/native-staking/src/state.rs
+++ b/contracts/provider/native-staking/src/state.rs
@@ -12,6 +12,9 @@ pub struct Config {
     /// The address of the vault contract (where we get and return stake)
     pub vault: Addr,
 
-    /// Max slash percentage (from InstantiateMsg, maybe later from the chain)
-    pub max_slashing: Decimal,
+    /// Max slash percentage for double signing
+    pub max_slashing_dsign: Decimal,
+
+    /// max slash percentage for being offline
+    pub max_slashing_offline: Decimal,
 }

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -9,7 +9,7 @@ use std::cmp::min;
 
 use mesh_apis::cross_staking_api::CrossStakingApiHelper;
 use mesh_apis::local_staking_api::{
-    LocalStakingApiHelper, LocalStakingApiQueryMsg, MaxSlashResponse,
+    LocalStakingApiHelper, LocalStakingApiQueryMsg, SlashRatioResponse,
 };
 use mesh_apis::vault_api::{self, SlashInfo, VaultApi};
 use mesh_sync::Tx::InFlightStaking;
@@ -193,7 +193,7 @@ impl VaultContract<'_> {
             &mut ctx,
             &config,
             &contract.0,
-            slashable.max_slash_dsign,
+            slashable.slash_ratio_dsign,
             amount.clone(),
             true,
         )?;
@@ -461,13 +461,13 @@ impl VaultContract<'_> {
         // As we control the local staking contract it might be better to just raw-query it
         // on demand instead of duplicating the data.
         let query = LocalStakingApiQueryMsg::MaxSlash {};
-        let MaxSlashResponse {
-            max_slash_dsign, ..
+        let SlashRatioResponse {
+            slash_ratio_dsign, ..
         } = deps.querier.query_wasm_smart(&local_staking, &query)?;
 
         let local_staking = LocalStaking {
             contract: LocalStakingApiHelper(local_staking),
-            max_slash: max_slash_dsign,
+            max_slash: slash_ratio_dsign,
         };
 
         self.local_staking

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -193,7 +193,7 @@ impl VaultContract<'_> {
             &mut ctx,
             &config,
             &contract.0,
-            slashable.max_slash,
+            slashable.max_slash_dsign,
             amount.clone(),
             true,
         )?;
@@ -461,12 +461,13 @@ impl VaultContract<'_> {
         // As we control the local staking contract it might be better to just raw-query it
         // on demand instead of duplicating the data.
         let query = LocalStakingApiQueryMsg::MaxSlash {};
-        let MaxSlashResponse { max_slash } =
-            deps.querier.query_wasm_smart(&local_staking, &query)?;
+        let MaxSlashResponse {
+            max_slash_dsign, ..
+        } = deps.querier.query_wasm_smart(&local_staking, &query)?;
 
         let local_staking = LocalStaking {
             contract: LocalStakingApiHelper(local_staking),
-            max_slash,
+            max_slash: max_slash_dsign,
         };
 
         self.local_staking

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -3,6 +3,7 @@ use cw_multi_test::{App as MtApp, StakingInfo};
 use mesh_apis::ibc::AddValidator;
 use mesh_external_staking::contract::multitest_utils::ExternalStakingContractProxy;
 use mesh_external_staking::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo};
+use mesh_external_staking::state::MaxSlashing;
 use mesh_external_staking::state::Stake;
 use mesh_external_staking::test_methods_impl::test_utils::TestMethods;
 use mesh_native_staking::contract::multitest_utils::NativeStakingContractProxy;
@@ -123,7 +124,8 @@ fn setup_inner<'app>(
 
         let native_staking_inst_msg = mesh_native_staking::contract::InstantiateMsg {
             denom: OSMO.to_string(),
-            max_slashing: Decimal::percent(10),
+            max_slashing_dsign: Decimal::percent(10),
+            max_slashing_offline: Decimal::percent(10),
             proxy_code_id: native_staking_proxy_code.code_id(),
         };
 
@@ -170,7 +172,10 @@ fn setup_cross_stake<'app>(
             vault.contract_addr.to_string(),
             unbond_period,
             remote_contact,
-            Decimal::percent(slash_percent),
+            MaxSlashing {
+                double_sign: Decimal::percent(slash_percent),
+                offline: Decimal::percent(slash_percent),
+            },
         )
         .call(owner)
         .unwrap()

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -3,7 +3,7 @@ use cw_multi_test::{App as MtApp, StakingInfo};
 use mesh_apis::ibc::AddValidator;
 use mesh_external_staking::contract::multitest_utils::ExternalStakingContractProxy;
 use mesh_external_staking::msg::{AuthorizedEndpoint, ReceiveVirtualStake, StakeInfo};
-use mesh_external_staking::state::MaxSlashing;
+use mesh_external_staking::state::SlashRatio;
 use mesh_external_staking::state::Stake;
 use mesh_external_staking::test_methods_impl::test_utils::TestMethods;
 use mesh_native_staking::contract::multitest_utils::NativeStakingContractProxy;
@@ -124,8 +124,8 @@ fn setup_inner<'app>(
 
         let native_staking_inst_msg = mesh_native_staking::contract::InstantiateMsg {
             denom: OSMO.to_string(),
-            max_slashing_dsign: Decimal::percent(10),
-            max_slashing_offline: Decimal::percent(10),
+            slash_ratio_dsign: Decimal::percent(10),
+            slash_ratio_offline: Decimal::percent(10),
             proxy_code_id: native_staking_proxy_code.code_id(),
         };
 
@@ -172,7 +172,7 @@ fn setup_cross_stake<'app>(
             vault.contract_addr.to_string(),
             unbond_period,
             remote_contact,
-            MaxSlashing {
+            SlashRatio {
                 double_sign: Decimal::percent(slash_percent),
                 offline: Decimal::percent(slash_percent),
             },

--- a/packages/apis/src/cross_staking_api.rs
+++ b/packages/apis/src/cross_staking_api.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{to_binary, Addr, Binary, Coin, Deps, Response, StdError, Wasm
 use sylvia::types::{ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
-pub use crate::local_staking_api::MaxSlashResponse;
+pub use crate::local_staking_api::SlashRatioResponse;
 
 /// This is the interface to any cross staking contract needed by the vault contract.
 /// That is, using the vault collateral to stake on a system that doesn't use the collateral
@@ -45,7 +45,7 @@ pub trait CrossStakingApi {
 
     /// Returns the maximum percentage that can be slashed
     #[msg(query)]
-    fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error>;
+    fn max_slash(&self, ctx: QueryCtx) -> Result<SlashRatioResponse, Self::Error>;
 }
 
 #[cw_serde]
@@ -97,7 +97,7 @@ impl CrossStakingApiHelper {
         Ok(wasm)
     }
 
-    pub fn max_slash(&self, deps: Deps) -> Result<MaxSlashResponse, StdError> {
+    pub fn max_slash(&self, deps: Deps) -> Result<SlashRatioResponse, StdError> {
         let query = CrossStakingApiQueryMsg::MaxSlash {};
         deps.querier.query_wasm_smart(&self.0, &query)
     }

--- a/packages/apis/src/local_staking_api.rs
+++ b/packages/apis/src/local_staking_api.rs
@@ -5,7 +5,8 @@ use sylvia::{interface, schemars};
 
 #[cw_serde]
 pub struct MaxSlashResponse {
-    pub max_slash: Decimal,
+    pub max_slash_dsign: Decimal,
+    pub max_slash_offline: Decimal,
 }
 
 /// This is the interface to any local staking contract needed by the vault contract.

--- a/packages/apis/src/local_staking_api.rs
+++ b/packages/apis/src/local_staking_api.rs
@@ -4,9 +4,9 @@ use sylvia::types::{ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
 #[cw_serde]
-pub struct MaxSlashResponse {
-    pub max_slash_dsign: Decimal,
-    pub max_slash_offline: Decimal,
+pub struct SlashRatioResponse {
+    pub slash_ratio_dsign: Decimal,
+    pub slash_ratio_offline: Decimal,
 }
 
 /// This is the interface to any local staking contract needed by the vault contract.
@@ -46,7 +46,7 @@ pub trait LocalStakingApi {
 
     /// Returns the maximum percentage that can be slashed
     #[msg(query)]
-    fn max_slash(&self, ctx: QueryCtx) -> Result<MaxSlashResponse, Self::Error>;
+    fn max_slash(&self, ctx: QueryCtx) -> Result<SlashRatioResponse, Self::Error>;
 }
 
 #[cw_serde]
@@ -94,7 +94,7 @@ impl LocalStakingApiHelper {
         Ok(wasm)
     }
 
-    pub fn max_slash(&self, deps: Deps) -> Result<MaxSlashResponse, StdError> {
+    pub fn max_slash(&self, deps: Deps) -> Result<SlashRatioResponse, StdError> {
         let query = LocalStakingApiQueryMsg::MaxSlash {};
         deps.querier.query_wasm_smart(&self.0, &query)
     }


### PR DESCRIPTION
Closes #151 

The changes to `native-staking` are there to support the modified `LocalStakingApi::max_slash`.