### PR TITLE
Slash amounts support

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -84,4 +84,4 @@ jobs:
         with:
           toolchain: 1.70.0
           command: clippy
-          args: --all-targets -- -D warnings
+          args: --all-targets -- -D warnings -A clippy::too-many-arguments

--- a/contracts/consumer/converter/src/error.rs
+++ b/contracts/consumer/converter/src/error.rs
@@ -32,7 +32,10 @@ pub enum ContractError {
     #[error("Invalid reply id: {0}")]
     InvalidReplyId(u64),
 
-    #[error("Invalid discount, must be between 0.0 and 1.0")]
+    #[error("Invalid price, must be greater than 0.0")]
+    InvalidPrice,
+
+    #[error("Invalid discount, must be greater or equal than 0.0 and less than 1.0")]
     InvalidDiscount,
 
     #[error("Invalid denom: {0}")]

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -9,6 +9,7 @@ use cosmwasm_std::{
 };
 use cw_storage_plus::Item;
 
+use mesh_apis::converter_api::ValidatorSlashInfo;
 use mesh_apis::ibc::{
     ack_success, validate_channel_order, AckWrapper, AddValidator, ConsumerPacket, ProtocolVersion,
     ProviderPacket, StakeAck, TransferRewardsAck, UnstakeAck, PROTOCOL_NAME,
@@ -115,7 +116,7 @@ pub fn ibc_channel_connect(
 
     // Send a validator sync packet to arrive with the newly established channel
     let validators = deps.querier.query_all_validators()?;
-    let msg = valset_update_msg(&env, &channel, &validators, &[], &[], &[], &[], &[])?;
+    let msg = valset_update_msg(&env, &channel, &validators, &[], &[], &[], &[], &[], &[])?;
 
     Ok(IbcBasicResponse::new().add_message(msg))
 }
@@ -130,6 +131,7 @@ pub(crate) fn valset_update_msg(
     jailed: &[String],
     unjailed: &[String],
     tombstoned: &[String],
+    slashed: &[ValidatorSlashInfo],
 ) -> Result<IbcMsg, ContractError> {
     let additions = additions
         .iter()
@@ -156,6 +158,7 @@ pub(crate) fn valset_update_msg(
         jailed: jailed.to_vec(),
         unjailed: unjailed.to_vec(),
         tombstoned: tombstoned.to_vec(),
+        slashed: slashed.to_vec(),
     };
     let msg = IbcMsg::SendPacket {
         channel_id: channel.endpoint.channel_id.clone(),

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -329,7 +329,7 @@ fn valset_update_works() {
     // Check that only the virtual staking contract can call this handler
     let res = converter
         .converter_api_proxy()
-        .valset_update(vec![], vec![], vec![], vec![], vec![], vec![])
+        .valset_update(vec![], vec![], vec![], vec![], vec![], vec![], vec![])
         .call(owner);
     assert_eq!(res.unwrap_err(), Unauthorized {});
 
@@ -338,6 +338,7 @@ fn valset_update_works() {
         .valset_update(
             add_validators,
             rem_validators,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -397,7 +398,7 @@ fn unauthorized() {
 
     let err = converter
         .converter_api_proxy()
-        .valset_update(vec![], vec![], vec![], vec![], vec![], vec![])
+        .valset_update(vec![], vec![], vec![], vec![], vec![], vec![], vec![])
         .call("mallory")
         .unwrap_err();
 

--- a/contracts/consumer/virtual-staking/src/multitest.rs
+++ b/contracts/consumer/virtual-staking/src/multitest.rs
@@ -155,6 +155,7 @@ fn valset_update_sudo() {
         jailed: None,
         unjailed: None,
         tombstoned: Some(tombs),
+        slashed: None,
     };
 
     let res = app

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1574,7 +1574,7 @@ mod tests {
     }
 
     #[test]
-    fn valset_update_tombstoning_slashes() {
+    fn valset_update_tombstoning_and_slashing() {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
@@ -1629,7 +1629,7 @@ mod tests {
         // Commit stake
         contract.commit_stake(stake_deps, 1).unwrap();
 
-        // Bob is tombstoned next
+        // Bob is slashed and tombstoned next
         let update_ctx = ctx.branch();
         let tombs = vec!["bob".to_string()];
         let (evt, msgs) = contract
@@ -1644,12 +1644,25 @@ mod tests {
                 &[],
                 &[],
                 &tombs,
-                &[],
+                &[ValidatorSlashInfo {
+                    address: "bob".to_string(),
+                    infraction_height: 200,
+                    infraction_time: 2345,
+                    power: 100,
+                    slash_amount: coin(10, "uosmo"),
+                    slash_ratio: Decimal::percent(10).to_string(),
+                }],
             )
             .unwrap();
 
         // Check the event
-        assert_eq!(evt.attributes, vec![Attribute::new("tombstoned", "bob"),]);
+        assert_eq!(
+            evt.attributes,
+            vec![
+                Attribute::new("tombstoned", "bob"),
+                Attribute::new("slashed", "bob")
+            ]
+        );
 
         // Check the slashing message
         assert_eq!(msgs.len(), 1);
@@ -1692,7 +1705,7 @@ mod tests {
     }
 
     #[test]
-    fn valset_update_tombstoning_slashes_pending_bond() {
+    fn valset_update_tombstoning_and_slashing_pending_bond() {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
@@ -1746,7 +1759,7 @@ mod tests {
             .unwrap();
         // Stake tx is pending
 
-        // Bob is tombstoned next
+        // Bob is slashed and tombstoned next
         let update_ctx = ctx.branch();
         let tombs = vec!["bob".to_string()];
         let (evt, msgs) = contract
@@ -1761,12 +1774,25 @@ mod tests {
                 &[],
                 &[],
                 &tombs,
-                &[],
+                &[ValidatorSlashInfo {
+                    address: "bob".to_string(),
+                    infraction_height: 200,
+                    infraction_time: 2345,
+                    power: 100,
+                    slash_amount: coin(10, "uosmo"),
+                    slash_ratio: Decimal::percent(10).to_string(),
+                }],
             )
             .unwrap();
 
         // Check the event
-        assert_eq!(evt.attributes, vec![Attribute::new("tombstoned", "bob"),]);
+        assert_eq!(
+            evt.attributes,
+            vec![
+                Attribute::new("tombstoned", "bob"),
+                Attribute::new("slashed", "bob")
+            ]
+        );
 
         // Check the slashing message
         assert_eq!(msgs.len(), 1);
@@ -1809,7 +1835,7 @@ mod tests {
     }
 
     #[test]
-    fn valset_update_tombstoning_slashes_pending_unbond() {
+    fn valset_update_tombstoning_and_slashing_pending_unbond() {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
@@ -1877,7 +1903,7 @@ mod tests {
             .unwrap();
         // Unstake tx is pending
 
-        // Bob is tombstoned next
+        // Bob is slashed and tombstoned next
         let update_ctx = ctx.branch();
         let tombs = vec!["bob".to_string()];
         let (evt, msgs) = contract
@@ -1892,12 +1918,25 @@ mod tests {
                 &[],
                 &[],
                 &tombs,
-                &[],
+                &[ValidatorSlashInfo {
+                    address: "bob".to_string(),
+                    infraction_height: 200,
+                    infraction_time: 2345,
+                    power: 100,
+                    slash_amount: coin(10, "uosmo"),
+                    slash_ratio: Decimal::percent(10).to_string(),
+                }],
             )
             .unwrap();
 
         // Check the event
-        assert_eq!(evt.attributes, vec![Attribute::new("tombstoned", "bob"),]);
+        assert_eq!(
+            evt.attributes,
+            vec![
+                Attribute::new("tombstoned", "bob"),
+                Attribute::new("slashed", "bob")
+            ]
+        );
 
         // Check the slashing message
         assert_eq!(msgs.len(), 1);
@@ -1940,7 +1979,7 @@ mod tests {
     }
 
     #[test]
-    fn valset_update_tombstoning_slashes_no_stake() {
+    fn valset_update_tombstoning_and_slashing_no_stake() {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
@@ -1973,7 +2012,7 @@ mod tests {
             .unwrap();
         // Bob has no cross-delegations (which can be possible)
 
-        // Bob is tombstoned next
+        // Bob is slashed and tombstoned next
         let update_ctx = ctx.branch();
         let tombs = vec!["bob".to_string()];
         let (evt, msgs) = contract
@@ -2210,7 +2249,7 @@ mod tests {
     }
 
     #[test]
-    fn valset_update_jailing_slashes() {
+    fn valset_update_jailing_and_slashing() {
         let mut deps = mock_dependencies();
         let (mut ctx, contract) = do_instantiate(deps.as_mut());
 
@@ -2265,7 +2304,7 @@ mod tests {
         // Commit stake
         contract.commit_stake(stake_deps, 1).unwrap();
 
-        // Bob is jailed next
+        // Bob is slashed and jailed next
         let update_ctx = ctx.branch();
         let jails = vec!["bob".to_string()];
         let (evt, msgs) = contract
@@ -2280,12 +2319,25 @@ mod tests {
                 &jails,
                 &[],
                 &[],
-                &[],
+                &[ValidatorSlashInfo {
+                    address: "bob".to_string(),
+                    infraction_height: 200,
+                    infraction_time: 2345,
+                    power: 100,
+                    slash_amount: coin(10, "uosmo"),
+                    slash_ratio: Decimal::percent(10).to_string(),
+                }],
             )
             .unwrap();
 
         // Check the event
-        assert_eq!(evt.attributes, vec![Attribute::new("jailed", "bob"),]);
+        assert_eq!(
+            evt.attributes,
+            vec![
+                Attribute::new("jailed", "bob"),
+                Attribute::new("slashed", "bob")
+            ]
+        );
 
         // Check the slashing message
         assert_eq!(msgs.len(), 1);

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -134,6 +134,7 @@ pub fn ibc_packet_receive(
             jailed,
             unjailed,
             tombstoned,
+            slashed,
         } => {
             let (evt, msgs) = contract.valset_update(
                 deps,
@@ -146,6 +147,7 @@ pub fn ibc_packet_receive(
                 &jailed,
                 &unjailed,
                 &tombstoned,
+                &slashed,
             )?;
             let ack = ack_success(&ValsetUpdateAck {})?;
             IbcReceiveResponse::new()

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1359,7 +1359,7 @@ fn slashing() {
     // But now validators[0] slashing happens
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string())
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(8))
         .call("test")
         .unwrap();
 
@@ -1444,7 +1444,7 @@ fn slashing_pending_tx_partial_unbond() {
     // Now validators[0] slashing happens
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string())
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 
@@ -1527,7 +1527,7 @@ fn slashing_pending_tx_full_unbond() {
     // Now validators[0] slashing happens
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string())
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 
@@ -1612,7 +1612,7 @@ fn slashing_pending_tx_full_unbond_rolled_back() {
     // Now validators[0] slashing happens
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string())
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 
@@ -1717,7 +1717,7 @@ fn slashing_pending_tx_bond() {
     // Now validators[0] slashing happens
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string())
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 
@@ -1804,7 +1804,7 @@ fn slashing_pending_tx_bond_rolled_back() {
     // Now validators[0] slashing happens
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string())
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -1714,10 +1714,10 @@ fn slashing_pending_tx_bond() {
         ValueRange::new(Uint128::new(250), Uint128::new(300))
     );
 
-    // Now validators[0] slashing happens
+    // Now validators[0] slashing happens, over the amount included the pending bond
     contract
         .test_methods_proxy()
-        .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
+        .test_handle_slashing(validators[0].to_string(), Uint128::new(25))
         .call("test")
         .unwrap();
 
@@ -1801,20 +1801,20 @@ fn slashing_pending_tx_bond_rolled_back() {
         ValueRange::new(Uint128::new(250), Uint128::new(300))
     );
 
-    // Now validators[0] slashing happens
+    // Now validators[0] slashing happens, but over the amount without the pending bond
     contract
         .test_methods_proxy()
         .test_handle_slashing(validators[0].to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 
-    // Claims on vault got reduced, for high end of pending slashed bond
+    // Claims on vault got reduced, for *low* end of pending slashed bond
     let claim = vault
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
     assert_eq!(
         claim.amount,
-        ValueRange::new(Uint128::new(225), Uint128::new(275))
+        ValueRange::new(Uint128::new(230), Uint128::new(280))
     );
 
     // Now the extra bond gets rolled back (i.e. failed)
@@ -1828,5 +1828,5 @@ fn slashing_pending_tx_bond_rolled_back() {
     let claim = vault
         .claim(user.to_owned(), contract.contract_addr.to_string())
         .unwrap();
-    assert_eq!(claim.amount.val().unwrap().u128(), 225);
+    assert_eq!(claim.amount.val().unwrap().u128(), 230);
 }

--- a/contracts/provider/external-staking/src/state.rs
+++ b/contracts/provider/external-staking/src/state.rs
@@ -93,12 +93,19 @@ impl Stake {
     }
 
     /// Slashes all the entries in `pending_unbonds`, returning total slashed amount.
-    pub fn slash_pending(&mut self, info: &BlockInfo, slash_ratio: Decimal) -> Uint128 {
-        // TODO: Only slash undelegations that started after the misbehaviour's time. This is not
-        //       possible right now, because we don't have access to the misbehaviour's time. (#177)
+    pub fn slash_pending(
+        &mut self,
+        info: &BlockInfo,
+        slash_ratio: Decimal,
+        unbonding_period: u64,
+        infraction_time: u64,
+    ) -> Uint128 {
         self.pending_unbonds
             .iter_mut()
-            .filter(|pending| pending.release_at > info.time)
+            .filter(|pending| {
+                pending.release_at.seconds() - unbonding_period > infraction_time
+                    && pending.release_at > info.time
+            })
             .map(|pending| {
                 let slash = pending.amount * slash_ratio;
                 // Slash it

--- a/contracts/provider/external-staking/src/test_methods.rs
+++ b/contracts/provider/external-staking/src/test_methods.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, Response, StdError};
+use cosmwasm_std::{Coin, Response, StdError, Uint128};
 use mesh_apis::converter_api::RewardInfo;
 use mesh_apis::ibc::AddValidator;
 use sylvia::interface;
@@ -97,5 +97,6 @@ pub trait TestMethods {
         &self,
         ctx: ExecCtx,
         validator: String,
+        slash_amount: Uint128,
     ) -> Result<Response, Self::Error>;
 }

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -2,7 +2,7 @@ use crate::contract::ExternalStakingContract;
 use crate::error::ContractError;
 use crate::test_methods::TestMethods;
 
-use cosmwasm_std::{Coin, Response};
+use cosmwasm_std::{Coin, Response, Uint128};
 use mesh_apis::converter_api::RewardInfo;
 use mesh_apis::ibc::AddValidator;
 use sylvia::contract;
@@ -225,6 +225,7 @@ impl TestMethods for ExternalStakingContract<'_> {
         &self,
         ctx: ExecCtx,
         validator: String,
+        slash_amount: Uint128,
     ) -> Result<Response, ContractError> {
         #[cfg(any(test, feature = "mt"))]
         {
@@ -235,6 +236,8 @@ impl TestMethods for ExternalStakingContract<'_> {
                 &cfg,
                 &validator,
                 cfg.slash_ratio.double_sign,
+                slash_amount,
+                ctx.env.block.time.seconds(),
             )?;
             match slash_msg {
                 Some(msg) => Ok(Response::new().add_message(msg)),
@@ -243,7 +246,7 @@ impl TestMethods for ExternalStakingContract<'_> {
         }
         #[cfg(not(any(test, feature = "mt")))]
         {
-            let _ = (ctx, validator);
+            let _ = (ctx, validator, slash_amount);
             Err(ContractError::Unauthorized {})
         }
     }

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -234,7 +234,7 @@ impl TestMethods for ExternalStakingContract<'_> {
                 ctx.deps.storage,
                 &cfg,
                 &validator,
-                crate::contract::SlashingReason::DoubleSign,
+                cfg.slash_ratio.double_sign,
             )?;
             match slash_msg {
                 Some(msg) => Ok(Response::new().add_message(msg)),

--- a/contracts/provider/external-staking/src/test_methods_impl.rs
+++ b/contracts/provider/external-staking/src/test_methods_impl.rs
@@ -235,9 +235,9 @@ impl TestMethods for ExternalStakingContract<'_> {
                 ctx.deps.storage,
                 &cfg,
                 &validator,
-                cfg.slash_ratio.double_sign,
+                cfg.slash_ratio.double_sign, // TODO: Add slash ratio parameter
                 slash_amount,
-                ctx.env.block.time.seconds(),
+                0, // TODO: Add infraction time parameter
             )?;
             match slash_msg {
                 Some(msg) => Ok(Response::new().add_message(msg)),

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -1749,7 +1749,7 @@ fn cross_slash_scenario_1() {
     // Validator 1 is slashed
     cross_staking
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(validator1.to_string(), Uint128::new(10))
         .call("test")
         .unwrap();
 
@@ -1861,7 +1861,7 @@ fn cross_slash_scenario_2() {
     // Validator 1 is slashed
     cross_staking
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(validator1.to_string(), Uint128::new(20))
         .call("test")
         .unwrap();
 
@@ -1969,7 +1969,7 @@ fn cross_slash_scenario_3() {
     // Validator 1 is slashed
     cross_staking
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(validator1.to_string(), Uint128::new(15))
         .call("test")
         .unwrap();
 
@@ -2102,7 +2102,7 @@ fn cross_slash_scenario_4() {
     // Validator 1 is slashed
     cross_staking_1
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(validator1.to_string(), Uint128::new(14))
         .call("test")
         .unwrap();
 
@@ -2279,7 +2279,10 @@ fn cross_slash_scenario_5() {
     // Validator 1 is slashed
     cross_staking_1
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(
+            validator1.to_string(),
+            Uint128::new(180) * Decimal::percent(slashing_percentage),
+        )
         .call("test")
         .unwrap();
 
@@ -2419,7 +2422,7 @@ fn cross_slash_no_native_staking() {
     // Validator 1 is slashed
     cross_staking_1
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(validator1.to_string(), Uint128::new(14))
         .call("test")
         .unwrap();
 
@@ -2548,10 +2551,10 @@ fn cross_slash_pending_unbonding() {
     assert_eq!(cross_stake1.stake, ValueRange::new_val(Uint128::new(50)));
     assert_eq!(cross_stake1.pending_unbonds[0].amount, Uint128::new(50));
 
-    // Validator 1 is slashed
+    // Validator 1 is slashed, over the current bond
     cross_staking
         .test_methods_proxy()
-        .test_handle_slashing(validator1.to_string())
+        .test_handle_slashing(validator1.to_string(), Uint128::new(5))
         .call("test")
         .unwrap();
 

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -62,9 +62,9 @@ pub struct ValidatorSlashInfo {
     pub infraction_time: u64,
     /// The validator power when the misbehaviour occurred.
     pub power: u64,
+    /// The slash amount over the amount delegated by virtual-staking for the validator.
+    pub slash_amount: Coin,
     /// The (nominal) slash ratio for the validator.
     /// Useful in case we don't know if it's a double sign or downtime slash.
     pub slash_ratio: String,
-    /// The slash amount for the validator.
-    pub slash_amount: Coin,
 }

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Response, StdError, Uint128, Validator};
+use cosmwasm_std::{Coin, Response, StdError, Uint128, Validator};
 use sylvia::types::ExecCtx;
 use sylvia::{interface, schemars};
 
@@ -41,6 +41,7 @@ pub trait ConverterApi {
         jailed: Vec<String>,
         unjailed: Vec<String>,
         tombstoned: Vec<String>,
+        slashed: Vec<ValidatorSlashInfo>,
     ) -> Result<Response, Self::Error>;
 }
 
@@ -49,4 +50,21 @@ pub trait ConverterApi {
 pub struct RewardInfo {
     pub validator: String,
     pub reward: Uint128,
+}
+
+#[cw_serde]
+pub struct ValidatorSlashInfo {
+    /// The address of the validator.
+    pub address: String,
+    /// The height at which the misbehaviour occurred.
+    pub infraction_height: u64,
+    /// The time at which the misbehaviour occurred, in seconds.
+    pub infraction_time: u64,
+    /// The validator power when the misbehaviour occurred.
+    pub power: u64,
+    /// The (nominal) slash ratio for the validator.
+    /// Useful in case we don't know if it's a double sign or downtime slash.
+    pub slash_ratio: String,
+    /// The slash amount for the validator.
+    pub slash_amount: Coin,
 }

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Binary, Coin, Decimal, StdResult, Timestamp};
 
-use crate::converter_api::RewardInfo;
+use crate::converter_api::{RewardInfo, ValidatorSlashInfo};
 
 /// These are messages sent from provider -> consumer
 /// ibc_packet_receive in converter must handle them all.
@@ -104,6 +104,11 @@ pub enum ConsumerPacket {
         /// If the validator doesn't exist or is already tombstoned, this is a no-op for that validator.
         /// This has precedence over all other events in the same packet
         tombstoned: Vec<String>,
+        /// This is sent when a validator is slashed.
+        /// If the validator doesn't exist or is inactive at the infraction height, this is a no-op
+        /// for that validator.
+        /// This has precedence over all other events in the same packet.
+        slashed: Vec<ValidatorSlashInfo>,
     },
     /// This is part of the rewards protocol
     Distribute {

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -61,5 +61,25 @@ pub enum SudoMsg {
         jailed: Option<Vec<String>>,
         unjailed: Option<Vec<String>>,
         tombstoned: Option<Vec<String>>,
+        slashed: Option<Vec<ValidatorSlash>>,
     },
+}
+
+#[cw_serde]
+pub struct ValidatorSlash {
+    /// The operator address of the validator (e.g. cosmosvaloper1...).
+    pub address: String,
+    /// The height at which the slash is being processed.
+    pub height: u64,
+    /// The time at which the slash is being processed, in seconds.
+    pub time: u64,
+    /// The height at which the misbehaviour occurred.
+    pub infraction_height: u64,
+    /// The time at which the misbehaviour occurred.
+    pub infraction_time: u64,
+    /// The validator power when the misbehaviour occurred.
+    pub power: u64,
+    /// The (nominal) slash ratio for the validator.
+    /// Useful in case we don't know if it's a double sign or downtime slash.
+    pub slash_ratio: String,
 }

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -79,6 +79,8 @@ pub struct ValidatorSlash {
     pub infraction_time: u64,
     /// The validator power when the misbehaviour occurred.
     pub power: u64,
+    /// The slashed amount over the virtual-staking contract.
+    pub slash_amount: String,
     /// The (nominal) slash ratio for the validator.
     /// Useful in case we don't know if it's a double sign or downtime slash.
     pub slash_ratio: String,

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -67,7 +67,7 @@ pub enum SudoMsg {
 
 #[cw_serde]
 pub struct ValidatorSlash {
-    /// The operator address of the validator (e.g. cosmosvaloper1...).
+    /// The address of the validator.
     pub address: String,
     /// The height at which the slash is being processed.
     pub height: u64,
@@ -75,7 +75,7 @@ pub struct ValidatorSlash {
     pub time: u64,
     /// The height at which the misbehaviour occurred.
     pub infraction_height: u64,
-    /// The time at which the misbehaviour occurred.
+    /// The time at which the misbehaviour occurred, in seconds.
     pub infraction_time: u64,
     /// The validator power when the misbehaviour occurred.
     pub power: u64,

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, Response, StdError, Validator};
+use cosmwasm_std::{Coin, Response, StdError, Uint128, Validator};
 use sylvia::types::ExecCtx;
 use sylvia::{interface, schemars};
 
@@ -80,7 +80,7 @@ pub struct ValidatorSlash {
     /// The validator power when the misbehaviour occurred.
     pub power: u64,
     /// The slashed amount over the virtual-staking contract.
-    pub slash_amount: String,
+    pub slash_amount: Uint128,
     /// The (nominal) slash ratio for the validator.
     /// Useful in case we don't know if it's a double sign or downtime slash.
     pub slash_ratio: String,


### PR DESCRIPTION
Related to https://github.com/osmosis-labs/mesh-security-sdk/pull/125.

Adds support for slashing based on historical evidence (double signing slashing), through slashing amounts instead of slash ratios.

There are still some limitations and there's room for improvement in the contracts side impls. Will be documented in a number of follow-up issues.

**TODO**:

- [x] Fix / adapt / extend tests.
- [ ] Improve coverage / Add tests.