### PR TITLE
feat(vault): `active_external_staking` query

### DIFF
--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -71,6 +71,11 @@ pub struct ConfigResponse {
     pub local_staking: Option<String>,
 }
 
+#[cw_serde]
+pub struct AllActiveExternalStakingResponse {
+    pub contracts: Vec<String>,
+}
+
 pub type TxResponse = Tx;
 pub type AllTxsResponseItem = TxResponse;
 

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -16,7 +16,10 @@ use crate::contract;
 use crate::contract::multitest_utils::VaultContractProxy;
 use crate::contract::test_utils::VaultApi;
 use crate::error::ContractError;
-use crate::msg::{AccountResponse, AllAccountsResponseItem, LienResponse, StakingInitInfo, AllActiveExternalStakingResponse};
+use crate::msg::{
+    AccountResponse, AllAccountsResponseItem, AllActiveExternalStakingResponse, LienResponse,
+    StakingInitInfo,
+};
 
 const OSMO: &str = "OSMO";
 const STAR: &str = "star";
@@ -484,14 +487,6 @@ fn local_staking_disabled() {
             free: ValueRange::new(Uint128::new(200), Uint128::new(300)),
         }
     );
-
-    let res = vault.active_external_staking().unwrap();
-    assert_eq!(
-        res,
-        AllActiveExternalStakingResponse{
-            contracts: vec![cross_staking.contract_addr.to_string()],
-        }
-    );
 }
 
 #[test]
@@ -720,6 +715,9 @@ fn stake_cross() {
         coin(0, OSMO)
     );
 
+    let res = vault.active_external_staking().unwrap();
+    assert_eq!(res, AllActiveExternalStakingResponse { contracts: vec![] });
+
     // Staking remotely
     vault
         .stake_remote(
@@ -732,6 +730,14 @@ fn stake_cross() {
         )
         .call(user)
         .unwrap();
+
+    let res = vault.active_external_staking().unwrap();
+    assert_eq!(
+        res,
+        AllActiveExternalStakingResponse {
+            contracts: vec![cross_staking.contract_addr.to_string()],
+        }
+    );
 
     let acc = vault.account(user.to_owned()).unwrap();
     assert_eq!(

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -16,7 +16,7 @@ use crate::contract;
 use crate::contract::multitest_utils::VaultContractProxy;
 use crate::contract::test_utils::VaultApi;
 use crate::error::ContractError;
-use crate::msg::{AccountResponse, AllAccountsResponseItem, LienResponse, StakingInitInfo};
+use crate::msg::{AccountResponse, AllAccountsResponseItem, LienResponse, StakingInitInfo, AllActiveExternalStakingResponse};
 
 const OSMO: &str = "OSMO";
 const STAR: &str = "star";
@@ -482,6 +482,14 @@ fn local_staking_disabled() {
             denom: OSMO.to_owned(),
             bonded: Uint128::new(300),
             free: ValueRange::new(Uint128::new(200), Uint128::new(300)),
+        }
+    );
+
+    let res = vault.active_external_staking().unwrap();
+    assert_eq!(
+        res,
+        AllActiveExternalStakingResponse{
+            contracts: vec![cross_staking.contract_addr.to_string()],
         }
     );
 }


### PR DESCRIPTION
In the provider vault, a list of active external contracts is needed for our Vault fork (a [Proof of Authority](https://github.com/strangelove-ventures/poa) network using Mesh). Figured it was useful to upstream as well

New contracts are added on any successful local `stake_remote`