### PR TITLE
Only ignore codegen source file in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ node_modules
 
 
 # Codegen builds in src
-src
+/src
 
 
 # Optional npm cache directory


### PR DESCRIPTION
My bad, should only ignore the codegen `src` folder in directory root.