### PR TITLE
Upgrade deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "autocfg"
@@ -50,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "byteorder"
@@ -123,11 +129,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.4.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fb22494cf7d23d0c348740e06e5c742070b2991fd41db77bba0bcfbae1a723"
+checksum = "e6b4c3f9c4616d6413d4b5fc4c270a4cc32a374b9be08671e80e1a019f805d8f"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa 0.16.8",
  "ed25519-zebra",
  "k256 0.13.1",
  "rand_core 0.6.4",
@@ -136,18 +143,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.4.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e199424486ea97d6b211db6387fd72e26b4a439d40cc23140b2d8305728055b"
+checksum = "c586ced10c3b00e809ee664a895025a024f60d65d34fe4c09daed4a4db68a3f3"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.3.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99222fa0401ee36389550d8a065700380877a2299c3043d24c38d705708c9d9d"
+checksum = "8467874827d384c131955ff6f4d47d02e72a956a08eb3c0ff24f8c903a5517b4"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -158,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.3.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b74eaf9e585ef8e5e3486b240b13ee593cb0f658b5879696937d8c22243d4fb"
+checksum = "f6db85d98ac80922aef465e564d5b21fa9cfac5058cb62df7f116c3682337393"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -169,11 +176,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.4.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d89d680fb60439b7c5947b15f9c84b961b88d1f8a3b20c4bd178a3f87db8bae"
+checksum = "712fe58f39d55c812f7b2c84e097cdede3a39d520f89b6dc3153837e31741927"
 dependencies = [
  "base64",
+ "bech32",
  "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
@@ -183,7 +191,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde-json-wasm",
- "sha2 0.10.7",
+ "sha2 0.10.8",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -264,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
+checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -275,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
+checksum = "1c4a657e5caacc3a0d00ee96ca8618745d050b8f757c709babafb81208d4239c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -290,14 +299,15 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ac2dc7a55ad64173ca1e0a46697c31b7a5c51342f55a1e84a724da4eb99908"
+checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
@@ -573,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -595,7 +605,7 @@ dependencies = [
  "cfg-if",
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -608,7 +618,7 @@ dependencies = [
  "ecdsa 0.16.8",
  "elliptic-curve 0.13.6",
  "once_cell",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "signature 2.1.0",
 ]
 
@@ -874,7 +884,7 @@ dependencies = [
  "cw-utils",
  "cw2",
  "derivative",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "mesh-apis",
  "mesh-bindings",
  "mesh-burn",
@@ -1006,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -1070,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1121,9 +1131,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "schemars"
-version = "0.8.13"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
+checksum = "7f55c82c700538496bdc329bb4918a81f87cc8888811bd123cf325a0f2f8d309"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -1133,14 +1143,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.13"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
+checksum = "83263746fe5e32097f06356968a077f96089739c927a61450efa069905eec108"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1173,15 +1183,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -1197,33 +1207,33 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1252,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1300,6 +1310,12 @@ dependencies = [
  "base64ct",
  "der 0.7.8",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1353,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1364,44 +1380,55 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "2.2.2"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d6cf5a7dffb3f9dceec8e6b8ca528d9bd71d36c9f074defb548ce161f598c0"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
 dependencies = [
  "test-case-macros",
 ]
 
 [[package]]
-name = "test-case-macros"
-version = "2.2.2"
+name = "test-case-core"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,23 +25,23 @@ mesh-simple-price-feed    = { path = "./contracts/consumer/simple-price-feed" }
 mesh-virtual-staking    = { path = "./contracts/consumer/virtual-staking" }
 
 sylvia           = "0.8.1"
-cosmwasm-schema  = "1.3.3"
-cosmwasm-std     = { version = "1.3.3", features = ["ibc3", "cosmwasm_1_3"] }
-cw-storage-plus  = "1.1.0"
-cw-utils         = "1.0.1"
-cw2              = "1.0.1"
+cosmwasm-schema  = "1.5.4"
+cosmwasm-std     = { version = "1.5.4", features = ["ibc3", "cosmwasm_1_3"] }
+cw-storage-plus  = "1.2.0"
+cw-utils         = "1.0.3"
+cw2              = "1.1.2"
 osmosis-std      = "0.20.1"
-schemars         = "0.8.11"
-serde            = { version = "1.0.152", default-features = false, features = ["derive"] }
-thiserror        = "1.0.38"
-semver = "1.0.4"
-itertools = "0.11.0"
+schemars         = "0.8.17"
+serde            = { version = "1.0.199", default-features = false, features = ["derive"] }
+thiserror        = "1.0.59"
+semver = "1.0.22"
+itertools = "0.12.1"
 
 # dev deps
 anyhow        = "1"
 cw-multi-test = "0.16.5"
 derivative    = "2"
-test-case     = "2.2.0"
+test-case     = "3.3.1"
 
 [profile.release]
 codegen-units    = 1

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    ensure_eq, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event, Fraction,
-    MessageInfo, Reply, Response, SubMsg, SubMsgResponse, Uint128, Validator, WasmMsg,
+    ensure_eq, to_json_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Event,
+    Fraction, MessageInfo, Reply, Response, SubMsg, SubMsgResponse, Uint128, Validator, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
@@ -203,7 +203,7 @@ impl ConverterContract<'_> {
         let msg = virtual_staking_api::ExecMsg::Bond { validator, amount };
         let msg = WasmMsg::Execute {
             contract_addr: self.virtual_stake.load(deps.storage)?.into(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
 
@@ -227,7 +227,7 @@ impl ConverterContract<'_> {
         let msg = virtual_staking_api::ExecMsg::Unbond { validator, amount };
         let msg = WasmMsg::Execute {
             contract_addr: self.virtual_stake.load(deps.storage)?.into(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
 
@@ -254,7 +254,7 @@ impl ConverterContract<'_> {
         };
         let msg = WasmMsg::Execute {
             contract_addr: self.virtual_stake.load(deps.storage)?.into(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
 

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -188,7 +188,7 @@ pub fn ibc_packet_receive(
     _env: Env,
     msg: IbcPacketReceiveMsg,
 ) -> Result<IbcReceiveResponse, ContractError> {
-    let packet: ProviderPacket = from_json(&msg.packet.data)?;
+    let packet: ProviderPacket = from_json(msg.packet.data)?;
     let contract = ConverterContract::new();
     let res = match packet {
         ProviderPacket::Stake {

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -352,7 +352,9 @@ fn valset_update_works() {
     assert_eq!(
         res.unwrap_err(),
         ContractError::Std(StdError::NotFound {
-            kind: "cosmwasm_std::ibc::IbcChannel".to_string()
+            kind:
+                "type: cosmwasm_std::ibc::IbcChannel; key: [69, 62, 63, 5F, 63, 68, 61, 6E, 6E, 65, 6C]"
+                    .to_string()
         })
     );
 }

--- a/contracts/consumer/remote-price-feed/src/ibc.rs
+++ b/contracts/consumer/remote-price-feed/src/ibc.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
-    from_slice, to_binary, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
+    from_json, to_json_binary, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
     IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcMsg,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
     Timestamp,
@@ -65,7 +65,7 @@ pub fn ibc_channel_open(
     }
 
     // we handshake with the counterparty version, it must not be empty
-    let v: ProtocolVersion = from_slice(counterparty_version.as_bytes())?;
+    let v: ProtocolVersion = from_json(counterparty_version.as_bytes())?;
     // if we can build a response to this, then it is compatible. And we use the highest version there
     let version = v.build_response(SUPPORTED_IBC_PROTOCOL_VERSION, MIN_IBC_PROTOCOL_VERSION)?;
 
@@ -125,7 +125,7 @@ pub fn ibc_packet_ack(
     _env: Env,
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    let ack: PriceFeedProviderAck = from_slice(&msg.acknowledgement.data)?;
+    let ack: PriceFeedProviderAck = from_json(&msg.acknowledgement.data)?;
     let PriceFeedProviderAck::Update { time, twap } = ack;
     let contract = RemotePriceFeedContract::new();
     contract.update_twap(deps, time, twap)?;
@@ -149,7 +149,7 @@ pub(crate) fn make_ibc_packet(
 ) -> Result<IbcMsg, ContractError> {
     Ok(IbcMsg::SendPacket {
         channel_id: channel.endpoint.channel_id,
-        data: to_binary(&packet)?,
+        data: to_json_binary(&packet)?,
         timeout: packet_timeout(now),
     })
 }

--- a/contracts/consumer/remote-price-feed/src/ibc.rs
+++ b/contracts/consumer/remote-price-feed/src/ibc.rs
@@ -125,7 +125,7 @@ pub fn ibc_packet_ack(
     _env: Env,
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    let ack: PriceFeedProviderAck = from_json(&msg.acknowledgement.data)?;
+    let ack: PriceFeedProviderAck = from_json(msg.acknowledgement.data)?;
     let PriceFeedProviderAck::Update { time, twap } = ack;
     let contract = RemotePriceFeedContract::new();
     contract.update_twap(deps, time, twap)?;

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use cosmwasm_std::{
-    coin, ensure_eq, entry_point, to_binary, Coin, CosmosMsg, CustomQuery, DepsMut,
+    coin, ensure_eq, entry_point, to_json_binary, Coin, CosmosMsg, CustomQuery, DepsMut,
     DistributionMsg, Env, Event, Reply, Response, StdResult, Storage, SubMsg, Uint128, Validator,
     WasmMsg,
 };
@@ -262,7 +262,7 @@ impl VirtualStakingContract<'_> {
         };
         let msg = WasmMsg::Execute {
             contract_addr: cfg.converter.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         let resp = Response::new().add_message(msg);
@@ -338,7 +338,7 @@ impl VirtualStakingContract<'_> {
             };
             let msg = WasmMsg::Execute {
                 contract_addr: cfg.converter.into_string(),
-                msg: to_binary(&msg)?,
+                msg: to_json_binary(&msg)?,
                 funds: vec![coin(total.into(), cfg.denom)],
             };
             Ok(Response::new().add_message(msg))
@@ -644,7 +644,7 @@ mod tests {
     };
 
     use cosmwasm_std::{
-        coins, from_binary,
+        coins, from_json,
         testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage},
         Decimal,
     };
@@ -1221,12 +1221,12 @@ mod tests {
                 match msg {
                     mesh_bindings::VirtualStakeQuery::BondStatus { .. } => {
                         cosmwasm_std::SystemResult::Ok(cosmwasm_std::ContractResult::Ok(
-                            to_binary(&*bs_copy.borrow()).unwrap(),
+                            to_json_binary(&*bs_copy.borrow()).unwrap(),
                         ))
                     }
                     mesh_bindings::VirtualStakeQuery::SlashRatio {} => {
                         cosmwasm_std::SystemResult::Ok(cosmwasm_std::ContractResult::Ok(
-                            to_binary(&*slash_ratio.borrow()).unwrap(),
+                            to_json_binary(&*slash_ratio.borrow()).unwrap(),
                         ))
                     }
                 }
@@ -1515,7 +1515,7 @@ mod tests {
                     ..
                 }] => {
                     if let converter_api::ExecMsg::DistributeRewards { mut payments } =
-                        from_binary(bin_msg).unwrap()
+                        from_json(bin_msg).unwrap()
                     {
                         payments.sort();
                         Self::Batch(payments)

--- a/contracts/osmosis-price-provider/src/ibc.rs
+++ b/contracts/osmosis-price-provider/src/ibc.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
-    from_slice, to_binary, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse,
+    from_json, to_json_binary, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse,
     IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
     StdError, Timestamp,
@@ -46,7 +46,7 @@ pub fn ibc_channel_open(
             version: SUPPORTED_IBC_PROTOCOL_VERSION.to_string(),
         }
     } else {
-        let v: ProtocolVersion = from_slice(channel.version.as_bytes())?;
+        let v: ProtocolVersion = from_json(channel.version.as_bytes())?;
         // if we can build a response to this, then it is compatible. And we use the highest version there
         v.build_response(SUPPORTED_IBC_PROTOCOL_VERSION, MIN_IBC_PROTOCOL_VERSION)?
     };
@@ -77,7 +77,7 @@ pub fn ibc_channel_connect(
 
     // Ensure the counterparty responded with a version we support.
     // Note: here, we error if it is higher than what we proposed originally
-    let v: ProtocolVersion = from_slice(counterparty_version.as_bytes())?;
+    let v: ProtocolVersion = from_json(counterparty_version.as_bytes())?;
     v.verify_compatibility(SUPPORTED_IBC_PROTOCOL_VERSION, MIN_IBC_PROTOCOL_VERSION)?;
 
     let contract = OsmosisPriceProvider::new();
@@ -124,12 +124,17 @@ pub fn ibc_packet_receive(
         pool_id,
         base_asset,
         quote_asset,
-    } = from_slice(&msg.packet.data)?;
+    } = from_json(&msg.packet.data)?;
     let contract = OsmosisPriceProvider::new();
 
     let time = env.block.time;
     let twap = contract.query_twap(deps, pool_id, base_asset, quote_asset)?;
-    Ok(IbcReceiveResponse::new().set_ack(to_binary(&PriceFeedProviderAck::Update { time, twap })?))
+    Ok(
+        IbcReceiveResponse::new().set_ack(to_json_binary(&PriceFeedProviderAck::Update {
+            time,
+            twap,
+        })?),
+    )
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/osmosis-price-provider/src/ibc.rs
+++ b/contracts/osmosis-price-provider/src/ibc.rs
@@ -124,7 +124,7 @@ pub fn ibc_packet_receive(
         pool_id,
         base_asset,
         quote_asset,
-    } = from_json(&msg.packet.data)?;
+    } = from_json(msg.packet.data)?;
     let contract = OsmosisPriceProvider::new();
 
     let time = env.block.time;

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -865,6 +865,7 @@ impl ExternalStakingContract<'_> {
     /// In test code, this is called from `test_handle_slashing`.
     /// In non-test code, this is being called from `ibc_packet_receive` (in the `ConsumerPacket::RemoveValidators`
     /// handler)
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_slashing(
         &self,
         env: &Env,
@@ -1236,7 +1237,7 @@ pub mod cross_staking {
             let owner = ctx.deps.api.addr_validate(&owner)?;
 
             // parse and validate message
-            let msg: ReceiveVirtualStake = from_json(&msg)?;
+            let msg: ReceiveVirtualStake = from_json(msg)?;
             if !self
                 .val_set
                 .is_active_validator(ctx.deps.storage, &msg.validator)?

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, ensure, ensure_eq, to_binary, Coin, Decimal, DepsMut, Env, Event, IbcMsg, Order,
+    coin, ensure, ensure_eq, to_json_binary, Coin, Decimal, DepsMut, Env, Event, IbcMsg, Order,
     Response, StdResult, Storage, Uint128, Uint256, WasmMsg,
 };
 use cw2::set_contract_version;
@@ -306,7 +306,7 @@ impl ExternalStakingContract<'_> {
         };
         let msg = IbcMsg::SendPacket {
             channel_id: channel.endpoint.channel_id,
-            data: to_binary(&packet)?,
+            data: to_json_binary(&packet)?,
             timeout: packet_timeout(&env),
         };
         // send packet if we are ibc enabled
@@ -783,7 +783,7 @@ impl ExternalStakingContract<'_> {
         let channel_id = IBC_CHANNEL.load(ctx.deps.storage)?.endpoint.channel_id;
         let send_msg = IbcMsg::SendPacket {
             channel_id,
-            data: to_binary(&packet)?,
+            data: to_json_binary(&packet)?,
             timeout: packet_timeout(&ctx.env),
         };
 
@@ -1206,7 +1206,7 @@ pub mod cross_staking {
     use crate::msg::ReceiveVirtualStake;
 
     use super::*;
-    use cosmwasm_std::{from_binary, Binary};
+    use cosmwasm_std::{from_json, Binary};
     use mesh_apis::{cross_staking_api::CrossStakingApi, local_staking_api::SlashRatioResponse};
 
     #[contract(module=crate::contract)]
@@ -1236,7 +1236,7 @@ pub mod cross_staking {
             let owner = ctx.deps.api.addr_validate(&owner)?;
 
             // parse and validate message
-            let msg: ReceiveVirtualStake = from_binary(&msg)?;
+            let msg: ReceiveVirtualStake = from_json(&msg)?;
             if !self
                 .val_set
                 .is_active_validator(ctx.deps.storage, &msg.validator)?
@@ -1276,7 +1276,7 @@ pub mod cross_staking {
             };
             let msg = IbcMsg::SendPacket {
                 channel_id: channel.endpoint.channel_id,
-                data: to_binary(&packet)?,
+                data: to_json_binary(&packet)?,
                 timeout: packet_timeout(&ctx.env),
             };
             // add ibc packet if we are ibc enabled (skip in tests)
@@ -1402,7 +1402,7 @@ pub mod cross_staking {
             };
             let msg = IbcMsg::SendPacket {
                 channel_id: channel.endpoint.channel_id,
-                data: to_binary(&packet)?,
+                data: to_json_binary(&packet)?,
                 timeout: packet_timeout(&ctx.env),
             };
             let mut resp = Response::new();
@@ -1620,7 +1620,7 @@ mod tests {
                 OWNER.to_string(),
                 coin(100, "uosmo"),
                 1,
-                to_binary(&ReceiveVirtualStake {
+                to_json_binary(&ReceiveVirtualStake {
                     validator: "bob".to_string(),
                 })
                 .unwrap(),
@@ -1670,7 +1670,7 @@ mod tests {
             msgs[0],
             WasmMsg::Execute {
                 contract_addr: "vault_addr".to_string(),
-                msg: to_binary(&CrossSlash {
+                msg: to_json_binary(&CrossSlash {
                     slashes: vec![SlashInfo {
                         user: OWNER.to_string(),
                         slash: Uint128::new(10),
@@ -1751,7 +1751,7 @@ mod tests {
                 OWNER.to_string(),
                 coin(100, "uosmo"),
                 1,
-                to_binary(&ReceiveVirtualStake {
+                to_json_binary(&ReceiveVirtualStake {
                     validator: "bob".to_string(),
                 })
                 .unwrap(),
@@ -1800,7 +1800,7 @@ mod tests {
             msgs[0],
             WasmMsg::Execute {
                 contract_addr: "vault_addr".to_string(),
-                msg: to_binary(&CrossSlash {
+                msg: to_json_binary(&CrossSlash {
                     slashes: vec![SlashInfo {
                         user: OWNER.to_string(),
                         slash: Uint128::new(10),
@@ -1881,7 +1881,7 @@ mod tests {
                 OWNER.to_string(),
                 coin(100, "uosmo"),
                 1,
-                to_binary(&ReceiveVirtualStake {
+                to_json_binary(&ReceiveVirtualStake {
                     validator: "bob".to_string(),
                 })
                 .unwrap(),
@@ -1944,7 +1944,7 @@ mod tests {
             msgs[0],
             WasmMsg::Execute {
                 contract_addr: "vault_addr".to_string(),
-                msg: to_binary(&CrossSlash {
+                msg: to_json_binary(&CrossSlash {
                     slashes: vec![SlashInfo {
                         user: OWNER.to_string(),
                         slash: Uint128::new(10), // Owner is slashed over the full stake, including pending
@@ -2295,7 +2295,7 @@ mod tests {
                 OWNER.to_string(),
                 coin(100, "uosmo"),
                 1,
-                to_binary(&ReceiveVirtualStake {
+                to_json_binary(&ReceiveVirtualStake {
                     validator: "bob".to_string(),
                 })
                 .unwrap(),
@@ -2345,7 +2345,7 @@ mod tests {
             msgs[0],
             WasmMsg::Execute {
                 contract_addr: "vault_addr".to_string(),
-                msg: to_binary(&CrossSlash {
+                msg: to_json_binary(&CrossSlash {
                     slashes: vec![SlashInfo {
                         user: OWNER.to_string(),
                         slash: Uint128::new(10),

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -123,7 +123,7 @@ pub fn ibc_packet_receive(
     // If a validator is in more than one of the events, the end result will depend on the
     // processing order below.
     let contract = ExternalStakingContract::new();
-    let packet: ConsumerPacket = from_json(&msg.packet.data)?;
+    let packet: ConsumerPacket = from_json(msg.packet.data)?;
     let resp = match packet {
         ConsumerPacket::ValsetUpdate {
             height,
@@ -251,7 +251,7 @@ pub fn ibc_packet_timeout(
     _env: Env,
     msg: IbcPacketTimeoutMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    let packet: ProviderPacket = from_json(&msg.packet.data)?;
+    let packet: ProviderPacket = from_json(msg.packet.data)?;
     let contract = ExternalStakingContract::new();
     let mut resp = IbcBasicResponse::new().add_attribute("action", "ibc_packet_timeout");
     match packet {

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
-    from_slice, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
+    from_json, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
     IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
 };
@@ -69,7 +69,7 @@ pub fn ibc_channel_open(
     }
 
     // we handshake with the counterparty version, it must not be empty
-    let v: ProtocolVersion = from_slice(counterparty_version.as_bytes())?;
+    let v: ProtocolVersion = from_json(counterparty_version.as_bytes())?;
     // if we can build a response to this, then it is compatible. And we use the highest version there
     let version = v.build_response(SUPPORTED_IBC_PROTOCOL_VERSION, MIN_IBC_PROTOCOL_VERSION)?;
 
@@ -123,7 +123,7 @@ pub fn ibc_packet_receive(
     // If a validator is in more than one of the events, the end result will depend on the
     // processing order below.
     let contract = ExternalStakingContract::new();
-    let packet: ConsumerPacket = from_slice(&msg.packet.data)?;
+    let packet: ConsumerPacket = from_json(&msg.packet.data)?;
     let resp = match packet {
         ConsumerPacket::ValsetUpdate {
             height,
@@ -178,9 +178,9 @@ pub fn ibc_packet_ack(
     env: Env,
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    let packet: ProviderPacket = from_slice(&msg.original_packet.data)?;
+    let packet: ProviderPacket = from_json(&msg.original_packet.data)?;
     let contract = ExternalStakingContract::new();
-    let ack: AckWrapper = from_slice(&msg.acknowledgement.data)?;
+    let ack: AckWrapper = from_json(&msg.acknowledgement.data)?;
     let mut resp = IbcBasicResponse::new();
 
     match (packet, ack) {
@@ -251,7 +251,7 @@ pub fn ibc_packet_timeout(
     _env: Env,
     msg: IbcPacketTimeoutMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    let packet: ProviderPacket = from_slice(&msg.packet.data)?;
+    let packet: ProviderPacket = from_json(&msg.packet.data)?;
     let contract = ExternalStakingContract::new();
     let mut resp = IbcBasicResponse::new().add_attribute("action", "ibc_packet_timeout");
     match packet {

--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use anyhow::Result as AnyResult;
 
-use cosmwasm_std::{coin, coins, to_binary, Decimal, Uint128};
+use cosmwasm_std::{coin, coins, to_json_binary, Decimal, Uint128};
 use mesh_native_staking::contract::multitest_utils::CodeId as NativeStakingCodeId;
 use mesh_native_staking::contract::InstantiateMsg as NativeStakingInstantiateMsg;
 use mesh_native_staking_proxy::contract::multitest_utils::CodeId as NativeStakingProxyCodeId;
@@ -60,7 +60,7 @@ fn setup<'app>(
     let staking_init = StakingInitInfo {
         admin: None,
         code_id: native_staking_code.code_id(),
-        msg: to_binary(&native_staking_instantiate)?,
+        msg: to_json_binary(&native_staking_instantiate)?,
         label: Some("Native staking".to_owned()),
     };
 
@@ -133,7 +133,7 @@ fn staking() {
 
     /*
     // Fail to stake on non-registered validator
-    let msg = to_binary(&ReceiveVirtualStake {
+    let msg = to_json_binary(&ReceiveVirtualStake {
         validator: "unknown".to_string(),
     })
     .unwrap();
@@ -836,7 +836,7 @@ fn distribution() {
         .stake_remote(
             contract.contract_addr.to_string(),
             coin(300, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validators[1].to_string(),
             })
             .unwrap(),
@@ -1683,7 +1683,7 @@ fn slashing_pending_tx_bond() {
         .stake_remote(
             contract.contract_addr.to_string(),
             coin(50, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validators[0].into(),
             })
             .unwrap(),
@@ -1770,7 +1770,7 @@ fn slashing_pending_tx_bond_rolled_back() {
         .stake_remote(
             contract.contract_addr.to_string(),
             coin(50, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validators[0].into(),
             })
             .unwrap(),

--- a/contracts/provider/external-staking/src/multitest/utils.rs
+++ b/contracts/provider/external-staking/src/multitest/utils.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, Coin};
+use cosmwasm_std::{to_json_binary, Addr, Coin};
 use cw_multi_test::{App as MtApp, AppResponse};
 use mesh_apis::{converter_api::RewardInfo, ibc::AddValidator};
 use mesh_sync::Tx;
@@ -136,7 +136,7 @@ impl VaultExt for Vault<'_> {
         self.stake_remote(
             contract.contract_addr.to_string(),
             coin,
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.into(),
             })
             .unwrap(),

--- a/contracts/provider/native-staking-proxy/src/contract.rs
+++ b/contracts/provider/native-staking-proxy/src/contract.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::WasmMsg::Execute;
 use cosmwasm_std::{
-    coin, ensure_eq, to_binary, Coin, DistributionMsg, GovMsg, Response, StakingMsg, VoteOption,
-    WeightedVoteOption,
+    coin, ensure_eq, to_json_binary, Coin, DistributionMsg, GovMsg, Response, StakingMsg,
+    VoteOption, WeightedVoteOption,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
@@ -69,7 +69,7 @@ impl NativeStakingProxyContract<'_> {
         };
 
         // Pass owner to caller's reply handler
-        let owner_msg = to_binary(&OwnerMsg { owner })?;
+        let owner_msg = to_json_binary(&OwnerMsg { owner })?;
         Ok(res.add_message(set_withdrawal).set_data(owner_msg))
     }
 
@@ -318,7 +318,7 @@ impl NativeStakingProxyContract<'_> {
         }
 
         // Send them to the parent contract via `release_proxy_stake`
-        let msg = to_binary(&native_staking_callback::ExecMsg::ReleaseProxyStake {})?;
+        let msg = to_json_binary(&native_staking_callback::ExecMsg::ReleaseProxyStake {})?;
 
         let wasm_msg = Execute {
             contract_addr: cfg.parent.to_string(),
@@ -411,7 +411,7 @@ mod tests {
         // Assert data payload
         assert_eq!(
             res.data.unwrap(),
-            to_binary(&OwnerMsg {
+            to_json_binary(&OwnerMsg {
                 owner: OWNER.to_owned(),
             })
             .unwrap()

--- a/contracts/provider/native-staking-proxy/src/multitest.rs
+++ b/contracts/provider/native-staking-proxy/src/multitest.rs
@@ -1,7 +1,7 @@
 use anyhow::Result as AnyResult;
 
 use cosmwasm_std::testing::mock_env;
-use cosmwasm_std::{coin, coins, to_binary, Addr, Decimal, Validator};
+use cosmwasm_std::{coin, coins, to_json_binary, Addr, Decimal, Validator};
 
 use cw_multi_test::{App as MtApp, StakingInfo, StakingSudo, SudoMsg};
 
@@ -65,7 +65,7 @@ fn setup<'app>(
     let staking_init_info = mesh_vault::msg::StakingInitInfo {
         admin: None,
         code_id: staking_code.code_id(),
-        msg: to_binary(&mesh_native_staking::contract::InstantiateMsg {
+        msg: to_json_binary(&mesh_native_staking::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
             slash_ratio_dsign: Decimal::percent(5),
@@ -94,7 +94,7 @@ fn setup<'app>(
         vault
             .stake_local(
                 coin(100, OSMO),
-                to_binary(&mesh_native_staking::msg::StakeMsg {
+                to_json_binary(&mesh_native_staking::msg::StakeMsg {
                     validator: validator.to_owned(),
                 })
                 .unwrap(),
@@ -175,7 +175,7 @@ fn staking() {
     vault
         .stake_local(
             coin(20, OSMO),
-            to_binary(&mesh_native_staking::msg::StakeMsg {
+            to_json_binary(&mesh_native_staking::msg::StakeMsg {
                 validator: validator.to_owned(),
             })
             .unwrap(),

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::entry_point;
 
 use cosmwasm_std::Order::Ascending;
 use cosmwasm_std::{
-    from_slice, Addr, Decimal, DepsMut, Env, Event, Reply, Response, StdResult, SubMsgResponse,
+    from_json, Addr, Decimal, DepsMut, Env, Event, Reply, Response, StdResult, SubMsgResponse,
     WasmMsg,
 };
 use cw2::set_contract_version;
@@ -200,7 +200,7 @@ impl NativeStakingContract<'_> {
         // Associate staking proxy with owner address
         let proxy_addr = Addr::unchecked(init_data.contract_address);
         let owner_data: OwnerMsg =
-            from_slice(&init_data.data.ok_or(ContractError::NoInstantiateData {})?)?;
+            from_json(&init_data.data.ok_or(ContractError::NoInstantiateData {})?)?;
         let owner_addr = deps.api.addr_validate(&owner_data.owner)?;
         self.proxy_by_owner
             .save(deps.storage, &owner_addr, &proxy_addr)?;

--- a/contracts/provider/native-staking/src/contract.rs
+++ b/contracts/provider/native-staking/src/contract.rs
@@ -200,7 +200,7 @@ impl NativeStakingContract<'_> {
         // Associate staking proxy with owner address
         let proxy_addr = Addr::unchecked(init_data.contract_address);
         let owner_data: OwnerMsg =
-            from_json(&init_data.data.ok_or(ContractError::NoInstantiateData {})?)?;
+            from_json(init_data.data.ok_or(ContractError::NoInstantiateData {})?)?;
         let owner_addr = deps.api.addr_validate(&owner_data.owner)?;
         self.proxy_by_owner
             .save(deps.storage, &owner_addr, &proxy_addr)?;

--- a/contracts/provider/native-staking/src/local_staking_api.rs
+++ b/contracts/provider/native-staking/src/local_staking_api.rs
@@ -37,7 +37,7 @@ impl LocalStakingApi for NativeStakingContract<'_> {
         let _paid = must_pay(&ctx.info, &cfg.denom)?;
 
         // Parse message to find validator to stake on
-        let StakeMsg { validator } = from_json(&msg)?;
+        let StakeMsg { validator } = from_json(msg)?;
 
         let owner_addr = ctx.deps.api.addr_validate(&owner)?;
 

--- a/contracts/provider/native-staking/src/multitest.rs
+++ b/contracts/provider/native-staking/src/multitest.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, coins, to_binary, Addr, Decimal, Delegation, StdError, Uint128, Validator,
+    coin, coins, to_json_binary, Addr, Decimal, Delegation, StdError, Uint128, Validator,
 };
 
 use cw_multi_test::{App as MtApp, StakingInfo};
@@ -162,7 +162,7 @@ fn receiving_stake() {
     ));
 
     // Receive some stake on behalf of user1 for validator
-    let stake_msg = to_binary(&msg::StakeMsg {
+    let stake_msg = to_json_binary(&msg::StakeMsg {
         validator: validator.to_owned(),
     })
     .unwrap();
@@ -186,7 +186,7 @@ fn receiving_stake() {
     assert_delegations(&app, &proxy1, &[(validator, 100)]);
 
     // Stake some more
-    let stake_msg = to_binary(&msg::StakeMsg {
+    let stake_msg = to_json_binary(&msg::StakeMsg {
         validator: validator.to_owned(),
     })
     .unwrap();
@@ -217,7 +217,7 @@ fn receiving_stake() {
     assert_delegations(&app, &proxy1, &[(validator, 150)]);
 
     // Receive some stake on behalf of user2 for validator
-    let stake_msg = to_binary(&msg::StakeMsg {
+    let stake_msg = to_json_binary(&msg::StakeMsg {
         validator: validator.to_owned(),
     })
     .unwrap();
@@ -264,7 +264,7 @@ fn releasing_proxy_stake() {
     let staking_init_info = mesh_vault::msg::StakingInitInfo {
         admin: None,
         code_id: staking_code.code_id(),
-        msg: to_binary(&crate::contract::InstantiateMsg {
+        msg: to_json_binary(&crate::contract::InstantiateMsg {
             denom: OSMO.to_owned(),
             proxy_code_id: staking_proxy_code.code_id(),
             slash_ratio_dsign: slashing_rate_dsign(),
@@ -308,7 +308,7 @@ fn releasing_proxy_stake() {
     vault
         .stake_local(
             coin(100, OSMO),
-            to_binary(&msg::StakeMsg {
+            to_json_binary(&msg::StakeMsg {
                 validator: validator.to_owned(),
             })
             .unwrap(),

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{coin, coins, to_binary, Addr, Decimal, Uint128, Validator};
+use cosmwasm_std::{coin, coins, to_json_binary, Addr, Decimal, Uint128, Validator};
 use cw_multi_test::{App as MtApp, StakingInfo};
 use mesh_apis::ibc::AddValidator;
 use mesh_external_staking::contract::multitest_utils::ExternalStakingContractProxy;
@@ -135,7 +135,7 @@ fn setup_inner<'app>(
         Some(StakingInitInfo {
             admin: None,
             code_id: native_staking_code.code_id(),
-            msg: to_binary(&native_staking_inst_msg).unwrap(),
+            msg: to_json_binary(&native_staking_inst_msg).unwrap(),
             label: None,
         })
     } else {
@@ -223,7 +223,7 @@ fn stake_locally(
     };
 
     vault
-        .stake_local(coin(stake, OSMO), to_binary(&msg).unwrap())
+        .stake_local(coin(stake, OSMO), to_json_binary(&msg).unwrap())
         .call(user)
 }
 
@@ -239,7 +239,7 @@ fn stake_remotely(
             .stake_remote(
                 cross_staking.contract_addr.to_string(),
                 coin(*amount, OSMO),
-                to_binary(&ReceiveVirtualStake {
+                to_json_binary(&ReceiveVirtualStake {
                     validator: validator.to_string(),
                 })
                 .unwrap(),
@@ -470,7 +470,7 @@ fn local_staking_disabled() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(100, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: remote_val.to_string(),
             })
             .unwrap(),
@@ -723,7 +723,7 @@ fn stake_cross() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(100, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -796,7 +796,7 @@ fn stake_cross() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(150, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -862,7 +862,7 @@ fn stake_cross() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(150, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -1118,7 +1118,7 @@ fn stake_cross_txs() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(100, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -1136,7 +1136,7 @@ fn stake_cross_txs() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(50, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -1151,7 +1151,7 @@ fn stake_cross_txs() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(100, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -1327,7 +1327,7 @@ fn stake_cross_rollback_tx() {
         .stake_remote(
             cross_staking.contract_addr.to_string(),
             coin(100, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),
@@ -1484,7 +1484,7 @@ fn multiple_stakes() {
         .stake_remote(
             cross_staking2.contract_addr.to_string(),
             coin(400, OSMO),
-            to_binary(&ReceiveVirtualStake {
+            to_json_binary(&ReceiveVirtualStake {
                 validator: validator.to_string(),
             })
             .unwrap(),

--- a/packages/apis/src/cross_staking_api.rs
+++ b/packages/apis/src/cross_staking_api.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, Binary, Coin, Deps, Response, StdError, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Coin, Deps, Response, StdError, WasmMsg};
 use sylvia::types::{ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
@@ -72,7 +72,7 @@ impl CrossStakingApiHelper {
         };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds,
         };
         Ok(wasm)
@@ -91,7 +91,7 @@ impl CrossStakingApiHelper {
         };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         Ok(wasm)

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Binary, Coin, Decimal, StdResult, Timestamp};
+use cosmwasm_std::{to_json_binary, Binary, Coin, Decimal, StdResult, Timestamp};
 
 use crate::converter_api::{RewardInfo, ValidatorSlashInfo};
 
@@ -166,14 +166,14 @@ pub enum AckWrapper {
 
 // create a serialized success message
 pub fn ack_success<T: serde::Serialize>(data: &T) -> StdResult<Binary> {
-    let res = AckWrapper::Result(to_binary(data)?);
-    to_binary(&res)
+    let res = AckWrapper::Result(to_json_binary(data)?);
+    to_json_binary(&res)
 }
 
 // create a serialized error message
 pub fn ack_fail<E: Error>(err: E) -> StdResult<Binary> {
     let res = AckWrapper::Error(err.to_string());
-    to_binary(&res)
+    to_json_binary(&res)
 }
 
 #[cw_serde]

--- a/packages/apis/src/ibc/version.rs
+++ b/packages/apis/src/ibc/version.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_vec, IbcOrder, StdResult};
+use cosmwasm_std::{to_json_vec, IbcOrder, StdResult};
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -108,7 +108,7 @@ impl ProtocolVersion {
     }
 
     pub fn to_string(&self) -> StdResult<String> {
-        let bytes = to_vec(self)?;
+        let bytes = to_json_vec(self)?;
         Ok(String::from_utf8(bytes)?)
     }
 }

--- a/packages/apis/src/local_staking_api.rs
+++ b/packages/apis/src/local_staking_api.rs
@@ -1,5 +1,7 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, Binary, Coin, Decimal, Deps, Response, StdError, WasmMsg};
+use cosmwasm_std::{
+    to_json_binary, Addr, Binary, Coin, Decimal, Deps, Response, StdError, WasmMsg,
+};
 use sylvia::types::{ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
@@ -69,7 +71,7 @@ impl LocalStakingApiHelper {
         let msg = LocalStakingApiExecMsg::ReceiveStake { owner, msg };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds,
         };
         Ok(wasm)
@@ -88,7 +90,7 @@ impl LocalStakingApiHelper {
         };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         Ok(wasm)

--- a/packages/apis/src/vault_api.rs
+++ b/packages/apis/src/vault_api.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, Coin, Response, StdError, Uint128, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, Coin, Response, StdError, Uint128, WasmMsg};
 use sylvia::types::ExecCtx;
 use sylvia::{interface, schemars};
 
@@ -90,7 +90,7 @@ impl VaultApiHelper {
         let msg = VaultApiExecMsg::ReleaseCrossStake { owner, amount };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds,
         };
         Ok(wasm)
@@ -106,7 +106,7 @@ impl VaultApiHelper {
         let msg = VaultApiExecMsg::ReleaseLocalStake { owner };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds,
         };
         Ok(wasm)
@@ -123,7 +123,7 @@ impl VaultApiHelper {
         };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         Ok(wasm)
@@ -140,7 +140,7 @@ impl VaultApiHelper {
         };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         Ok(wasm)
@@ -150,7 +150,7 @@ impl VaultApiHelper {
         let msg = VaultApiExecMsg::CommitTx { tx_id };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         Ok(wasm)
@@ -160,7 +160,7 @@ impl VaultApiHelper {
         let msg = VaultApiExecMsg::RollbackTx { tx_id };
         let wasm = WasmMsg::Execute {
             contract_addr: self.0.to_string(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         };
         Ok(wasm)

--- a/packages/virtual-staking-mock/src/lib.rs
+++ b/packages/virtual-staking-mock/src/lib.rs
@@ -2,8 +2,8 @@ use anyhow::Result as AnyResult;
 use cosmwasm_std::{
     coin,
     testing::{MockApi, MockStorage},
-    to_binary, Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, QuerierWrapper, Storage,
-    Uint128,
+    to_json_binary, Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, QuerierWrapper,
+    Storage, Uint128,
 };
 use cw_multi_test::{AppResponse, BankKeeper, Module, WasmKeeper};
 use cw_storage_plus::{Item, Map};
@@ -173,16 +173,16 @@ impl Module for VirtualStakingModule {
                 let cap = self.caps.load(storage, Addr::unchecked(&contract))?;
                 let bonded = self.bonded_for_contract(storage, Addr::unchecked(contract))?;
 
-                to_binary(&BondStatusResponse {
+                to_json_binary(&BondStatusResponse {
                     cap: coin(cap.u128(), &denom),
                     delegated: coin(bonded.u128(), denom),
                 })?
             }
             mesh_bindings::VirtualStakeQuery::SlashRatio {} => {
-                to_binary(&self.slash_ratio.load(storage)?)?
+                to_json_binary(&self.slash_ratio.load(storage)?)?
             }
         };
 
-        Ok(to_binary(&result)?)
+        Ok(to_json_binary(&result)?)
     }
 }


### PR DESCRIPTION
Starting the process of upgrading to a more modern `sylvia` and `cosmwasm_std` versions. Not going to target CW 2 just yet, because I don't want to break any of the Starship stuff Anmol has setup.

This PR:
- Bumps deps that aren't sylvia (coming soon in separate PR)
- Renames deprecated `to_binary` and `from_slice`
- Fixes one ibc test which now returns a slightly different error message

It's prep for a more involved PR that will get us on a later version of `sylvia`.