### PR TITLE
Allow instantiating vault with existing local staking contract

### DIFF
--- a/contracts/provider/external-staking/src/multitest.rs
+++ b/contracts/provider/external-staking/src/multitest.rs
@@ -8,7 +8,7 @@ use mesh_native_staking::contract::sv::InstantiateMsg as NativeStakingInstantiat
 use mesh_native_staking_proxy::contract::sv::mt::CodeId as NativeStakingProxyCodeId;
 use mesh_vault::contract::sv::mt::CodeId as VaultCodeId;
 use mesh_vault::contract::VaultContract;
-use mesh_vault::msg::StakingInitInfo;
+use mesh_vault::msg::{LocalStakingInfo, StakingInitInfo};
 
 use mesh_sync::ValueRange;
 
@@ -70,7 +70,7 @@ fn setup<'app>(
     };
 
     let vault = vault_code
-        .instantiate(OSMO.to_owned(), Some(staking_init))
+        .instantiate(OSMO.to_owned(), Some(LocalStakingInfo::New(staking_init)))
         .call(owner)?;
 
     let remote_contact = AuthorizedEndpoint::new("connection-2", "wasm-osmo1foobarbaz");

--- a/contracts/provider/native-staking-proxy/src/multitest.rs
+++ b/contracts/provider/native-staking-proxy/src/multitest.rs
@@ -9,6 +9,7 @@ use sylvia::multitest::{App, Proxy};
 
 use mesh_vault::contract::sv::mt::VaultContractProxy;
 use mesh_vault::contract::VaultContract;
+use mesh_vault::msg::LocalStakingInfo;
 
 use crate::contract;
 use crate::contract::sv::mt::NativeStakingProxyContractProxy;
@@ -80,7 +81,10 @@ fn setup<'app>(
 
     // Instantiates vault and staking
     let vault = vault_code
-        .instantiate(OSMO.to_owned(), Some(staking_init_info))
+        .instantiate(
+            OSMO.to_owned(),
+            Some(LocalStakingInfo::New(staking_init_info)),
+        )
         .with_label("Vault")
         .call(owner)
         .unwrap();

--- a/contracts/provider/native-staking/src/multitest.rs
+++ b/contracts/provider/native-staking/src/multitest.rs
@@ -12,6 +12,7 @@ use mesh_native_staking_proxy::contract::sv::mt::{
 use mesh_native_staking_proxy::contract::NativeStakingProxyContract;
 use mesh_sync::ValueRange;
 use mesh_vault::contract::sv::mt::VaultContractProxy;
+use mesh_vault::msg::LocalStakingInfo;
 
 use crate::contract;
 use crate::contract::sv::mt::NativeStakingContractProxy;
@@ -275,7 +276,10 @@ fn releasing_proxy_stake() {
 
     // Instantiates vault and staking contracts
     let vault = vault_code
-        .instantiate(OSMO.to_owned(), Some(staking_init_info))
+        .instantiate(
+            OSMO.to_owned(),
+            Some(LocalStakingInfo::New(staking_init_info)),
+        )
         .with_label("Vault")
         .call(owner)
         .unwrap();

--- a/contracts/provider/vault/src/msg.rs
+++ b/contracts/provider/vault/src/msg.rs
@@ -15,6 +15,23 @@ pub struct StakingInitInfo {
     pub label: Option<String>,
 }
 
+/// Information about the local staking contract used during vault instantiation
+/// We use untagged so older clients that just used JSON encoded StakingInitInfo
+/// will continue to work with no changes.
+#[cw_serde]
+pub enum LocalStakingInfo {
+    #[serde(untagged)]
+    Existing(ExistingContract),
+    #[serde(untagged)]
+    New(StakingInitInfo),
+}
+
+#[cw_serde]
+pub struct ExistingContract {
+    /// Address of the local staking contract
+    pub existing: String,
+}
+
 #[cw_serde]
 pub struct AccountResponse {
     // Everything is denom, changing all Uint128 to coin with the same denom seems very inefficient

--- a/contracts/provider/vault/src/multitest.rs
+++ b/contracts/provider/vault/src/multitest.rs
@@ -23,7 +23,7 @@ use crate::contract::VaultContract;
 use crate::error::ContractError;
 use crate::msg::{
     AccountResponse, AllAccountsResponseItem, AllActiveExternalStakingResponse, LienResponse,
-    StakingInitInfo,
+    LocalStakingInfo, StakingInitInfo,
 };
 
 const OSMO: &str = "OSMO";
@@ -137,12 +137,12 @@ fn setup_inner<'app>(
             proxy_code_id: native_staking_proxy_code.code_id(),
         };
 
-        Some(StakingInitInfo {
+        Some(LocalStakingInfo::New(StakingInitInfo {
             admin: None,
             code_id: native_staking_code.code_id(),
             msg: to_json_binary(&native_staking_inst_msg).unwrap(),
             label: None,
-        })
+        }))
     } else {
         None
     };


### PR DESCRIPTION
Was playing around with allowing a DAO to have its own mesh vault and realized we needed to be able to instantiate the vault from the local staking contract. Thanks to @ethanfrey for feedback and figuring out how we can clean support the existing interface used in the Mesh Security UI.