### PR TITLE
feat: Handle zero max cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "mesh-burn",
  "mesh-simple-price-feed",
  "mesh-sync",
+ "mesh-virtual-staking",
  "schemars",
  "serde",
  "sylvia",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "mesh-bindings",
  "mesh-burn",
  "mesh-simple-price-feed",
+ "mesh-sync",
  "schemars",
  "serde",
  "sylvia",

--- a/contracts/consumer/converter/Cargo.toml
+++ b/contracts/consumer/converter/Cargo.toml
@@ -24,6 +24,7 @@ fake-custom = [ "mesh-simple-price-feed/fake-custom" ]
 mesh-apis = { workspace = true }
 mesh-bindings = { workspace = true }
 mesh-sync = { workspace = true }
+mesh-virtual-staking = { workspace = true }
 
 sylvia = { workspace = true }
 cosmwasm-schema = { workspace = true }
@@ -39,7 +40,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 mesh-burn = { workspace = true }
 mesh-simple-price-feed = { workspace = true, features = ["mt"] }
-
+mesh-virtual-staking = { workspace = true, features = ["mt"] }
 cw-multi-test = { workspace = true }
 test-case = { workspace = true }
 derivative = { workspace = true }

--- a/contracts/consumer/converter/Cargo.toml
+++ b/contracts/consumer/converter/Cargo.toml
@@ -23,6 +23,7 @@ fake-custom = [ "mesh-simple-price-feed/fake-custom" ]
 [dependencies]
 mesh-apis = { workspace = true }
 mesh-bindings = { workspace = true }
+mesh-sync = { workspace = true }
 
 sylvia = { workspace = true }
 cosmwasm-schema = { workspace = true }

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -640,7 +640,7 @@ impl ConverterApi for ConverterContract<'_> {
         let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
 
         // Recalculate the price when unbond
-        let inverted_amount =  self.invert_price(ctx.deps.as_ref(), amount.clone())?;
+        let inverted_amount = self.invert_price(ctx.deps.as_ref(), amount.clone())?;
         let packet = ConsumerPacket::InternalUnstake {
             delegator,
             validator,

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -639,7 +639,7 @@ impl ConverterApi for ConverterContract<'_> {
 
         let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
         let packet = ConsumerPacket::InternalUnstake {
-            delegator: delegator,
+            delegator,
             validator,
             amount,
         };

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -640,11 +640,12 @@ impl ConverterApi for ConverterContract<'_> {
         let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
 
         // Recalculate the price when unbond
-        let amount = self.invert_price(ctx.deps.as_ref(), amount)?;
+        let inverted_amount =  self.invert_price(ctx.deps.as_ref(), amount.clone())?;
         let packet = ConsumerPacket::InternalUnstake {
             delegator,
             validator,
-            amount,
+            normalize_amount: amount,
+            inverted_amount,
         };
         let msg = IbcMsg::SendPacket {
             channel_id: channel.endpoint.channel_id,

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -74,6 +74,7 @@ impl ConverterContract<'_> {
         remote_denom: String,
         virtual_staking_code_id: u64,
         admin: Option<String>,
+        max_retrieve: u16,
     ) -> Result<custom::Response, ContractError> {
         nonpayable(&ctx.info)?;
         // validate args
@@ -97,11 +98,14 @@ impl ConverterContract<'_> {
             ctx.deps.api.addr_validate(admin)?;
         }
 
+        let msg = to_json_binary(&mesh_virtual_staking::contract::sv::InstantiateMsg{
+            max_retrieve
+        })?;
         // Instantiate virtual staking contract
         let init_msg = WasmMsg::Instantiate {
             admin,
             code_id: virtual_staking_code_id,
-            msg: b"{}".into(),
+            msg,
             funds: vec![],
             label: format!("Virtual Staking: {}", &config.remote_denom),
         };
@@ -151,7 +155,7 @@ impl ConverterContract<'_> {
         }
         #[cfg(not(any(test, feature = "mt")))]
         {
-            let _ = (ctx, validator, stake);
+            let _ = (ctx, delegator, validator, stake);
             Err(ContractError::Unauthorized)
         }
     }
@@ -173,7 +177,7 @@ impl ConverterContract<'_> {
         }
         #[cfg(not(any(test, feature = "mt")))]
         {
-            let _ = (ctx, validator, unstake);
+            let _ = (ctx, delegator, validator, unstake);
             Err(ContractError::Unauthorized)
         }
     }

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -638,6 +638,9 @@ impl ConverterApi for ConverterContract<'_> {
             .add_attribute("owner", delegator.clone());
 
         let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
+
+        // Recalculate the price when unbond
+        let amount = self.invert_price(ctx.deps.as_ref(), amount)?;
         let packet = ConsumerPacket::InternalUnstake {
             delegator,
             validator,

--- a/contracts/consumer/converter/src/contract.rs
+++ b/contracts/consumer/converter/src/contract.rs
@@ -98,9 +98,8 @@ impl ConverterContract<'_> {
             ctx.deps.api.addr_validate(admin)?;
         }
 
-        let msg = to_json_binary(&mesh_virtual_staking::contract::sv::InstantiateMsg{
-            max_retrieve
-        })?;
+        let msg =
+            to_json_binary(&mesh_virtual_staking::contract::sv::InstantiateMsg { max_retrieve })?;
         // Instantiate virtual staking contract
         let init_msg = WasmMsg::Instantiate {
             admin,

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -54,7 +54,10 @@ pub fn packet_timeout_rewards(env: &Env) -> IbcTimeout {
 pub fn packet_timeout_internal_unstake(env: &Env) -> IbcTimeout {
     // No idea about their block time, but 24 hours ahead of our view of the clock
     // should be decently in the future.
-    let timeout = env.block.time.plus_seconds(DEFAULT_INTERNAL_UNSTAKE_TIMEOUT);
+    let timeout = env
+        .block
+        .time
+        .plus_seconds(DEFAULT_INTERNAL_UNSTAKE_TIMEOUT);
     IbcTimeout::with_timestamp(timeout)
 }
 
@@ -267,15 +270,16 @@ pub fn ibc_packet_ack(
     match ack {
         AckWrapper::Result(_) => {
             let packet: ConsumerPacket = from_json(&msg.original_packet.data)?;
-            if let ConsumerPacket::InternalUnstake { 
-                delegator, 
-                validator, 
-                amount, 
-            } = packet {
-                // execute virtual contract's internal unbond 
+            if let ConsumerPacket::InternalUnstake {
+                delegator,
+                validator,
+                amount,
+            } = packet
+            {
+                // execute virtual contract's internal unbond
                 let msg = virtual_staking_api::sv::ExecMsg::InternalUnbond {
-                    delegator, 
-                    validator, 
+                    delegator,
+                    validator,
                     amount,
                 };
                 let msg = WasmMsg::Execute {

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     from_json, to_json_binary, DepsMut, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse,
     IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
     IbcChannelOpenResponse, IbcMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
-    IbcReceiveResponse, IbcTimeout, Validator,
+    IbcReceiveResponse, IbcTimeout, Validator, WasmMsg,
 };
 use cw_storage_plus::Item;
 
@@ -14,6 +14,7 @@ use mesh_apis::ibc::{
     ack_success, validate_channel_order, AckWrapper, AddValidator, ConsumerPacket, ProtocolVersion,
     ProviderPacket, StakeAck, TransferRewardsAck, UnstakeAck, PROTOCOL_NAME,
 };
+use mesh_apis::virtual_staking_api;
 use sylvia::types::ExecCtx;
 
 use crate::{
@@ -34,6 +35,8 @@ const DEFAULT_VALIDATOR_TIMEOUT: u64 = 24 * 60 * 60;
 // But reward messages should go faster or timeout
 const DEFAULT_REWARD_TIMEOUT: u64 = 60 * 60;
 
+const DEFAULT_INTERNAL_UNSTAKE_TIMEOUT: u64 = 60 * 60;
+
 pub fn packet_timeout_validator(env: &Env) -> IbcTimeout {
     // No idea about their block time, but 24 hours ahead of our view of the clock
     // should be decently in the future.
@@ -45,6 +48,13 @@ pub fn packet_timeout_rewards(env: &Env) -> IbcTimeout {
     // No idea about their block time, but 1 hour ahead of our view of the clock
     // should be decently in the future.
     let timeout = env.block.time.plus_seconds(DEFAULT_REWARD_TIMEOUT);
+    IbcTimeout::with_timestamp(timeout)
+}
+
+pub fn packet_timeout_internal_unstake(env: &Env) -> IbcTimeout {
+    // No idea about their block time, but 24 hours ahead of our view of the clock
+    // should be decently in the future.
+    let timeout = env.block.time.plus_seconds(DEFAULT_INTERNAL_UNSTAKE_TIMEOUT);
     IbcTimeout::with_timestamp(timeout)
 }
 
@@ -195,11 +205,12 @@ pub fn ibc_packet_receive(
     let contract = ConverterContract::new();
     let res = match packet {
         ProviderPacket::Stake {
+            delegator,
             validator,
             stake,
             tx_id: _,
         } => {
-            let response = contract.stake(deps, validator, stake)?;
+            let response = contract.stake(deps, delegator, validator, stake)?;
             let ack = ack_success(&StakeAck {})?;
             IbcReceiveResponse::new()
                 .set_ack(ack)
@@ -208,11 +219,12 @@ pub fn ibc_packet_receive(
                 .add_attributes(response.attributes)
         }
         ProviderPacket::Unstake {
+            delegator,
             validator,
             unstake,
             tx_id: _,
         } => {
-            let response = contract.unstake(deps, validator, unstake)?;
+            let response = contract.unstake(deps, delegator, validator, unstake)?;
             let ack = ack_success(&UnstakeAck {})?;
             IbcReceiveResponse::new()
                 .set_ack(ack)
@@ -245,14 +257,35 @@ pub fn ibc_packet_receive(
 /// If it succeeded, take no action. If it errored, we can't do anything else and let it go.
 /// We just log the error cases so they can be detected.
 pub fn ibc_packet_ack(
-    _deps: DepsMut,
+    deps: DepsMut,
     _env: Env,
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
     let ack: AckWrapper = from_json(&msg.acknowledgement.data)?;
+    let contract = ConverterContract::new();
     let mut res = IbcBasicResponse::new();
     match ack {
-        AckWrapper::Result(_) => {}
+        AckWrapper::Result(_) => {
+            let packet: ConsumerPacket = from_json(&msg.original_packet.data)?;
+            if let ConsumerPacket::InternalUnstake { 
+                delegator, 
+                validator, 
+                amount, 
+            } = packet {
+                // execute virtual contract's internal unbond 
+                let msg = virtual_staking_api::sv::ExecMsg::InternalUnbond {
+                    delegator, 
+                    validator, 
+                    amount,
+                };
+                let msg = WasmMsg::Execute {
+                    contract_addr: contract.virtual_stake.load(deps.storage)?.into(),
+                    msg: to_json_binary(&msg)?,
+                    funds: vec![],
+                };
+                res = res.add_message(msg);
+            }
+        }
         AckWrapper::Error(e) => {
             // The wasmd framework will label this with the contract_addr, which helps us find the port and issue.
             // Provide info to find the actual packet.

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -273,14 +273,16 @@ pub fn ibc_packet_ack(
             if let ConsumerPacket::InternalUnstake {
                 delegator,
                 validator,
-                amount,
+                normalize_amount,
+                inverted_amount: _,
             } = packet
             {
+
                 // execute virtual contract's internal unbond
                 let msg = virtual_staking_api::sv::ExecMsg::InternalUnbond {
                     delegator,
                     validator,
-                    amount,
+                    amount: normalize_amount,
                 };
                 let msg = WasmMsg::Execute {
                     contract_addr: contract.virtual_stake.load(deps.storage)?.into(),

--- a/contracts/consumer/converter/src/ibc.rs
+++ b/contracts/consumer/converter/src/ibc.rs
@@ -277,7 +277,6 @@ pub fn ibc_packet_ack(
                 inverted_amount: _,
             } = packet
             {
-
                 // execute virtual contract's internal unbond
                 let msg = virtual_staking_api::sv::ExecMsg::InternalUnbond {
                     delegator,

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -63,7 +63,7 @@ fn setup<'a>(app: &'a App<MtApp>, args: SetupArgs<'a>) -> SetupResponse<'a> {
             JUNO.to_owned(),
             virtual_staking_code.code_id(),
             Some(admin.to_owned()),
-            50
+            50,
         )
         .with_label("Juno Converter")
         .with_admin(admin)
@@ -259,7 +259,7 @@ fn ibc_stake_and_burn() {
 
     // let's stake some
     converter
-        .test_stake(owner.to_string(),val1.to_string(), coin(1000, JUNO))
+        .test_stake(owner.to_string(), val1.to_string(), coin(1000, JUNO))
         .call(owner)
         .unwrap();
     converter

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -63,6 +63,7 @@ fn setup<'a>(app: &'a App<MtApp>, args: SetupArgs<'a>) -> SetupResponse<'a> {
             JUNO.to_owned(),
             virtual_staking_code.code_id(),
             Some(admin.to_owned()),
+            50
         )
         .with_label("Juno Converter")
         .with_admin(admin)

--- a/contracts/consumer/converter/src/multitest.rs
+++ b/contracts/consumer/converter/src/multitest.rs
@@ -172,17 +172,17 @@ fn ibc_stake_and_unstake() {
 
     // let's stake some
     converter
-        .test_stake(val1.to_string(), coin(1000, JUNO))
+        .test_stake(owner.to_string(), val1.to_string(), coin(1000, JUNO))
         .call(owner)
         .unwrap();
     converter
-        .test_stake(val2.to_string(), coin(4000, JUNO))
+        .test_stake(owner.to_string(), val2.to_string(), coin(4000, JUNO))
         .call(owner)
         .unwrap();
 
     // and unstake some
     converter
-        .test_unstake(val2.to_string(), coin(2000, JUNO))
+        .test_unstake(owner.to_string(), val2.to_string(), coin(2000, JUNO))
         .call(owner)
         .unwrap();
 
@@ -258,11 +258,11 @@ fn ibc_stake_and_burn() {
 
     // let's stake some
     converter
-        .test_stake(val1.to_string(), coin(1000, JUNO))
+        .test_stake(owner.to_string(),val1.to_string(), coin(1000, JUNO))
         .call(owner)
         .unwrap();
     converter
-        .test_stake(val2.to_string(), coin(4000, JUNO))
+        .test_stake(owner.to_string(), val2.to_string(), coin(4000, JUNO))
         .call(owner)
         .unwrap();
 

--- a/contracts/consumer/converter/src/multitest/virtual_staking_mock.rs
+++ b/contracts/consumer/converter/src/multitest/virtual_staking_mock.rs
@@ -245,11 +245,11 @@ impl VirtualStakingApi for VirtualStakingMock<'_> {
 
     fn internal_unbond(
         &self,
-        _ctx:ExecCtx<Self::QueryC>,
-        _delegator:String,
-        _validator:String,
-        _amount:Coin
-    ) -> Result<Response<Self::ExecC> ,Self::Error> {
+        _ctx: ExecCtx<Self::QueryC>,
+        _delegator: String,
+        _validator: String,
+        _amount: Coin,
+    ) -> Result<Response<Self::ExecC>, Self::Error> {
         unimplemented!()
     }
 

--- a/contracts/consumer/converter/src/multitest/virtual_staking_mock.rs
+++ b/contracts/consumer/converter/src/multitest/virtual_staking_mock.rs
@@ -133,6 +133,7 @@ impl VirtualStakingApi for VirtualStakingMock<'_> {
     fn bond(
         &self,
         ctx: ExecCtx<Self::QueryC>,
+        _delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<Self::ExecC>, Self::Error> {
@@ -160,6 +161,7 @@ impl VirtualStakingApi for VirtualStakingMock<'_> {
     fn unbond(
         &self,
         ctx: ExecCtx<Self::QueryC>,
+        _delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<Self::ExecC>, Self::Error> {
@@ -239,6 +241,16 @@ impl VirtualStakingApi for VirtualStakingMock<'_> {
         }
 
         Ok(Response::new())
+    }
+
+    fn internal_unbond(
+        &self,
+        _ctx:ExecCtx<Self::QueryC>,
+        _delegator:String,
+        _validator:String,
+        _amount:Coin
+    ) -> Result<Response<Self::ExecC> ,Self::Error> {
+        unimplemented!()
     }
 
     /// SudoMsg::HandleEpoch{} should be called once per epoch by the sdk (in EndBlock).

--- a/contracts/consumer/virtual-staking/Cargo.toml
+++ b/contracts/consumer/virtual-staking/Cargo.toml
@@ -35,6 +35,7 @@ serde            = { workspace = true }
 thiserror        = { workspace = true }
 
 [dev-dependencies]
+sylvia        = { workspace = true, features = ["mt"] }
 mesh-simple-price-feed = { workspace = true, features = ["mt", "fake-custom"] }
 mesh-converter         = { workspace = true, features = ["mt", "fake-custom"] }
 cw-multi-test          = { workspace = true }

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -527,14 +527,15 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
             .collect::<Result<_, _>>()?;
         self.bonded.save(ctx.deps.storage, &requests)?;
 
-        let mut msgs: Vec<_> = vec![];
-        msgs.push(VirtualStakeMsg::UpdateDelegation {
-            amount: amount.clone(),
-            is_deduct: true,
-            delegator,
-            validator: validator.clone(),
-        });
-        msgs.push(VirtualStakeMsg::Unbond { amount, validator });
+        let msgs = vec![
+            VirtualStakeMsg::UpdateDelegation {
+                amount: amount.clone(),
+                is_deduct: true,
+                delegator,
+                validator: validator.clone(),
+            },
+            VirtualStakeMsg::Unbond { amount, validator }
+        ];
         Ok(Response::new().add_messages(msgs))
     }
 

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -578,6 +578,9 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
         if max_cap.is_zero() {
             let all_delegations = TokenQuerier::new(&deps.querier)
                 .all_delegations(env.contract.address.to_string(), config.max_retrieve)?;
+            if all_delegations.delegations.len() == 0 {
+                return Ok(resp.add_message(VirtualStakeMsg::DeleteAllScheduledTasks{}));
+            }
             let mut msgs = vec![];
             for delegation in all_delegations.delegations {
                 let validator = delegation.validator.clone();

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -534,10 +534,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
             delegator,
             validator: validator.clone(),
         });
-        msgs.push(VirtualStakeMsg::Unbond { 
-            amount, 
-            validator,
-        });
+        msgs.push(VirtualStakeMsg::Unbond { amount, validator });
         Ok(Response::new().add_messages(msgs))
     }
 

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -81,7 +81,7 @@ impl VirtualStakingContract<'_> {
         let config = Config {
             denom,
             converter: ctx.info.sender,
-            max_retrieve: max_retrieve,
+            max_retrieve,
         };
         self.config.save(ctx.deps.storage, &config)?;
         // initialize these to no one, so no issue when reading for the first time
@@ -526,7 +526,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
             )
             .collect::<Result<_, _>>()?;
         self.bonded.save(ctx.deps.storage, &requests)?;
-        return Ok(Response::new());
+        Ok(Response::new())
     }
 
     // FIXME: need to handle custom message types and queries
@@ -574,7 +574,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
                 // Send unstake request to converter contract
                 let msg = converter_api::sv::ExecMsg::InternalUnstake {
                     delegator: delegation.delegator,
-                    validator: validator,
+                    validator,
                     amount: Coin {
                         denom: config.denom.clone(),
                         amount: delegation.amount,

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -495,7 +495,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
     fn internal_unbond(
         &self,
         ctx: ExecCtx<VirtualStakeCustomQuery>,
-        _delegator: String,
+        delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<VirtualStakeCustomMsg>, Self::Error> {
@@ -526,7 +526,19 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
             )
             .collect::<Result<_, _>>()?;
         self.bonded.save(ctx.deps.storage, &requests)?;
-        Ok(Response::new())
+
+        let mut msgs: Vec<_> = vec![];
+        msgs.push(VirtualStakeMsg::UpdateDelegation {
+            amount: amount.clone(),
+            is_deduct: true,
+            delegator,
+            validator: validator.clone(),
+        });
+        msgs.push(VirtualStakeMsg::Unbond { 
+            amount, 
+            validator,
+        });
+        Ok(Response::new().add_messages(msgs))
     }
 
     // FIXME: need to handle custom message types and queries

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -534,7 +534,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
                 delegator,
                 validator: validator.clone(),
             },
-            VirtualStakeMsg::Unbond { amount, validator }
+            VirtualStakeMsg::Unbond { amount, validator },
         ];
         Ok(Response::new().add_messages(msgs))
     }
@@ -579,7 +579,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
             let all_delegations = TokenQuerier::new(&deps.querier)
                 .all_delegations(env.contract.address.to_string(), config.max_retrieve)?;
             if all_delegations.delegations.len() == 0 {
-                return Ok(resp.add_message(VirtualStakeMsg::DeleteAllScheduledTasks{}));
+                return Ok(resp.add_message(VirtualStakeMsg::DeleteAllScheduledTasks {}));
             }
             let mut msgs = vec![];
             for delegation in all_delegations.delegations {
@@ -1737,9 +1737,9 @@ mod tests {
 
         #[track_caller]
         fn assert_no_bonding(&self) -> &Self {
-            if !self.virtual_stake_msgs.is_empty() {
+            if self.virtual_stake_msgs.len() > 1 {
                 panic!(
-                    "hit_epoch result was expected to be a noop, but has these: {:?}",
+                    "hit_epoch result was expected to only contain DeleteAllScheduledTasks, but has these: {:?}",
                     self.virtual_stake_msgs
                 );
             }

--- a/contracts/consumer/virtual-staking/src/contract.rs
+++ b/contracts/consumer/virtual-staking/src/contract.rs
@@ -363,7 +363,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
     fn bond(
         &self,
         ctx: ExecCtx<VirtualStakeCustomQuery>,
-        _delegator: String,
+        delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<VirtualStakeCustomMsg>, Self::Error> {
@@ -385,7 +385,13 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
         self.bond_requests
             .save(ctx.deps.storage, &validator, &bonded)?;
 
-        Ok(Response::new())
+        let msg = VirtualStakeMsg::UpdateDelegation { 
+            amount, 
+            is_deduct: false,
+            delegator, 
+            validator 
+        };
+        Ok(Response::new().add_message(msg))
     }
 
     /// Requests to unbond tokens from a validator. This will be actually handled at the next epoch.
@@ -394,7 +400,7 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
     fn unbond(
         &self,
         ctx: ExecCtx<VirtualStakeCustomQuery>,
-        _delegator: String,
+        delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<VirtualStakeCustomMsg>, Self::Error> {
@@ -415,7 +421,13 @@ impl VirtualStakingApi for VirtualStakingContract<'_> {
         self.bond_requests
             .save(ctx.deps.storage, &validator, &bonded)?;
 
-        Ok(Response::new())
+        let msg = VirtualStakeMsg::UpdateDelegation { 
+            amount, 
+            is_deduct: true,
+            delegator, 
+            validator 
+        };
+        Ok(Response::new().add_message(msg))
     }
 
     /// Requests to unbond and burn tokens from a list of validators. Unbonding will be actually handled at the next epoch.

--- a/contracts/consumer/virtual-staking/src/multitest.rs
+++ b/contracts/consumer/virtual-staking/src/multitest.rs
@@ -60,6 +60,7 @@ fn setup<'a>(app: &'a App, args: SetupArgs<'a>) -> SetupResponse<'a> {
             JUNO.to_owned(),
             virtual_staking_code.code_id(),
             Some(admin.to_owned()),
+            50,
         )
         .with_label("Juno Converter")
         .with_admin(admin)

--- a/contracts/consumer/virtual-staking/src/state.rs
+++ b/contracts/consumer/virtual-staking/src/state.rs
@@ -8,4 +8,8 @@ pub struct Config {
 
     /// The address of the converter contract (that is authorized to bond/unbond and will receive rewards)
     pub converter: Addr,
+
+    /// Maximum 
+    /// 
+    pub max_retrieve: u16,
 }

--- a/contracts/consumer/virtual-staking/src/state.rs
+++ b/contracts/consumer/virtual-staking/src/state.rs
@@ -9,7 +9,7 @@ pub struct Config {
     /// The address of the converter contract (that is authorized to bond/unbond and will receive rewards)
     pub converter: Addr,
 
-    /// Maximum 
-    /// 
+    /// Maximum
+    ///
     pub max_retrieve: u16,
 }

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -26,7 +26,7 @@ use crate::msg::{
     StakeInfo, StakesResponse, TxResponse, ValidatorPendingRewards,
 };
 use crate::stakes::Stakes;
-use crate::state::{Config, Distribution, SlashRatio, Stake};
+use crate::state::{Config, Distribution, PendingUnbond, SlashRatio, Stake};
 
 pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -296,10 +296,11 @@ impl ExternalStakingContract<'_> {
         let mut resp = Response::new()
             .add_attribute("action", "unstake")
             .add_attribute("amount", amount.amount.to_string())
-            .add_attribute("owner", info.sender);
+            .add_attribute("owner", info.sender.clone());
 
         let channel = IBC_CHANNEL.load(deps.storage)?;
         let packet = ProviderPacket::Unstake {
+            delegator: info.sender.to_string(),
             validator,
             unstake: amount,
             tx_id,
@@ -443,6 +444,66 @@ impl ExternalStakingContract<'_> {
         // Remove tx
         self.pending_txs.remove(deps.storage, tx_id);
         Ok(())
+    }
+
+    pub(crate) fn internal_unstake(
+        &self,
+        deps: DepsMut,
+        env: Env,
+        delegator: String,
+        validator: String,
+        amount: Coin,
+    ) -> Result<Event, ContractError> {
+        let config = self.config.load(deps.storage)?;
+        let user = deps.api.addr_validate(&delegator)?;
+        // Load stake
+        let mut stake = self.stakes.stake.load(deps.storage, (&user, &validator))?;
+
+        // Load distribution
+        let mut distribution = self
+            .distribution
+            .may_load(deps.storage, &validator)?
+            .unwrap_or_default();
+
+        // Commit sub amount, saturating if slashed
+        let amount = min(amount.amount, stake.stake.high());
+        stake.stake.commit_sub(amount);
+
+        let immediate_release = matches!(
+            self.val_set.validator_state(deps.storage, &validator)?,
+            State::Unbonded {} | State::Tombstoned {}
+        );
+
+        // FIXME? Release period being computed after successful IBC tx
+        // (Note: this is good for now, but can be revisited in v1 design)
+        let release_at = if immediate_release {
+            env.block.time
+        } else {
+            env.block.time.plus_seconds(config.unbonding_period)
+        };
+        let unbond = PendingUnbond { amount, release_at };
+        stake.pending_unbonds.push(unbond);
+
+        // Distribution alignment
+        stake
+            .points_alignment
+            .stake_decreased(amount, distribution.points_per_stake);
+        distribution.total_stake -= amount;
+
+        // Save stake
+        self.stakes
+            .stake
+            .save(deps.storage, (&user, &validator), &stake)?;
+
+        // Save distribution
+        self.distribution
+            .save(deps.storage, &validator, &distribution)?;
+        let event = Event::new("internal_unstake")
+            .add_attribute("delegator", delegator)
+            .add_attribute("validator", validator)
+            .add_attribute("amount", amount.to_string());
+
+        Ok(event)
     }
 
     /// In non-test code, this is called from `ibc_packet_ack`
@@ -1271,6 +1332,7 @@ pub mod cross_staking {
 
             let channel = IBC_CHANNEL.load(ctx.deps.storage)?;
             let packet = ProviderPacket::Stake {
+                delegator: owner.to_string(),
                 validator: msg.validator,
                 stake: amount.clone(),
                 tx_id,

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -468,7 +468,7 @@ impl ExternalStakingContract<'_> {
         // Commit sub amount, saturating if slashed
         let amount = min(amount.amount, stake.stake.high());
         stake.stake.sub(amount, Uint128::zero())?;
-   
+
         let unbond = PendingUnbond {
             amount,
             release_at: env.block.time,

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -469,7 +469,10 @@ impl ExternalStakingContract<'_> {
         let amount = min(amount.amount, stake.stake.high());
         stake.stake.commit_sub(amount);
 
-        let unbond = PendingUnbond { amount, release_at: env.block.time };
+        let unbond = PendingUnbond {
+            amount,
+            release_at: env.block.time,
+        };
         stake.pending_unbonds.push(unbond);
 
         // Distribution alignment

--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -467,8 +467,8 @@ impl ExternalStakingContract<'_> {
 
         // Commit sub amount, saturating if slashed
         let amount = min(amount.amount, stake.stake.high());
-        stake.stake.commit_sub(amount);
-
+        stake.stake.sub(amount, Uint128::zero())?;
+   
         let unbond = PendingUnbond {
             amount,
             release_at: env.block.time,

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -155,6 +155,11 @@ pub fn ibc_packet_receive(
                 .add_event(evt)
                 .add_messages(msgs)
         }
+        ConsumerPacket::InternalUnstake { delegator, validator, amount} => {
+            let evt = contract.internal_unstake(deps, env, delegator, validator, amount)?;
+            let ack = ack_success(&DistributeAck {})?;
+            IbcReceiveResponse::new().set_ack(ack).add_event(evt)
+        }
         ConsumerPacket::Distribute { validator, rewards } => {
             let evt = contract.distribute_rewards(deps, &validator, rewards)?;
             let ack = ack_success(&DistributeAck {})?;

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -161,7 +161,8 @@ pub fn ibc_packet_receive(
             normalize_amount: _,
             inverted_amount,
         } => {
-            let evt = contract.internal_unstake(deps, env, delegator, validator, inverted_amount)?;
+            let evt =
+                contract.internal_unstake(deps, env, delegator, validator, inverted_amount)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -155,7 +155,11 @@ pub fn ibc_packet_receive(
                 .add_event(evt)
                 .add_messages(msgs)
         }
-        ConsumerPacket::InternalUnstake { delegator, validator, amount} => {
+        ConsumerPacket::InternalUnstake {
+            delegator,
+            validator,
+            amount,
+        } => {
             let evt = contract.internal_unstake(deps, env, delegator, validator, amount)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)

--- a/contracts/provider/external-staking/src/ibc.rs
+++ b/contracts/provider/external-staking/src/ibc.rs
@@ -158,9 +158,10 @@ pub fn ibc_packet_receive(
         ConsumerPacket::InternalUnstake {
             delegator,
             validator,
-            amount,
+            normalize_amount: _,
+            inverted_amount,
         } => {
-            let evt = contract.internal_unstake(deps, env, delegator, validator, amount)?;
+            let evt = contract.internal_unstake(deps, env, delegator, validator, inverted_amount)?;
             let ack = ack_success(&DistributeAck {})?;
             IbcReceiveResponse::new().set_ack(ack).add_event(evt)
         }

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    coin, ensure, Addr, BankMsg, Binary, Coin, Decimal, DepsMut, Fraction, Order, Reply, Response, StdResult, Storage, SubMsg, SubMsgResponse, Uint128, WasmMsg
+    coin, ensure, Addr, BankMsg, Binary, Coin, Decimal, DepsMut, Fraction, Order, Reply, Response,
+    StdResult, Storage, SubMsg, SubMsgResponse, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Bounder, Item, Map};

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, ensure, Addr, BankMsg, Binary, Coin, Decimal, DepsMut, Fraction, Order, Reply, Response, StdError, StdResult, Storage, SubMsg, SubMsgResponse, Uint128, WasmMsg
+    coin, ensure, Addr, BankMsg, Binary, Coin, Decimal, DepsMut, Fraction, Order, Reply, Response, StdResult, Storage, SubMsg, SubMsgResponse, Uint128, WasmMsg
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Bounder, Item, Map};
@@ -13,6 +13,7 @@ use mesh_apis::local_staking_api::{
 use mesh_apis::vault_api::{self, SlashInfo, VaultApi};
 use mesh_sync::Tx::InFlightStaking;
 use mesh_sync::{max_range, ValueRange};
+
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx, ReplyCtx};
 use sylvia::{contract, schemars};
 

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -1,6 +1,5 @@
 use cosmwasm_std::{
-    coin, ensure, Addr, BankMsg, Binary, Coin, Decimal, DepsMut, Fraction, Order, Reply, Response,
-    StdResult, Storage, SubMsg, SubMsgResponse, Uint128, WasmMsg,
+    coin, ensure, Addr, BankMsg, Binary, Coin, Decimal, DepsMut, Fraction, Order, Reply, Response, StdError, StdResult, Storage, SubMsg, SubMsgResponse, Uint128, WasmMsg
 };
 use cw2::set_contract_version;
 use cw_storage_plus::{Bounder, Item, Map};

--- a/packages/apis/src/converter_api.rs
+++ b/packages/apis/src/converter_api.rs
@@ -51,6 +51,16 @@ pub trait ConverterApi {
         tombstoned: Vec<String>,
         slashed: Vec<ValidatorSlashInfo>,
     ) -> Result<Response<Self::ExecC>, Self::Error>;
+
+    /// Send ibc packet, request the external staking contract to unstake
+    #[sv::msg(exec)]
+    fn internal_unstake(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        delegator: String,
+        validator: String,
+        amount: Coin,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 }
 
 #[cw_serde]

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -12,6 +12,7 @@ use crate::converter_api::{RewardInfo, ValidatorSlashInfo};
 pub enum ProviderPacket {
     /// This should be called when we lock more tokens to virtually stake on a given validator
     Stake {
+        delegator: String,
         validator: String,
         /// This is the local (provider-side) denom that is held in the vault.
         /// It will be converted to the consumer-side staking token in the converter with help
@@ -22,6 +23,7 @@ pub enum ProviderPacket {
     },
     /// This should be called when we begin the unbonding period of some more tokens previously virtually staked
     Unstake {
+        delegator: String,
         validator: String,
         /// This is the local (provider-side) denom that is held in the vault.
         /// It will be converted to the consumer-side staking token in the converter with help
@@ -109,6 +111,14 @@ pub enum ConsumerPacket {
         /// for that validator.
         /// This has precedence over all other events in the same packet.
         slashed: Vec<ValidatorSlashInfo>,
+    },
+    InternalUnstake {
+        delegator: String,
+        validator: String,
+        /// This is the local (provider-side) denom that is held in the vault.
+        /// It will be converted to the consumer-side staking token in the converter with help
+        /// of the price feed.
+        amount: Coin,
     },
     /// This is part of the rewards protocol
     Distribute {

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -120,7 +120,8 @@ pub enum ConsumerPacket {
         /// This is the local (provider-side) denom that is held in the vault.
         /// It will be converted to the consumer-side staking token in the converter with help
         /// of the price feed.
-        amount: Coin,
+        normalize_amount: Coin,
+        inverted_amount: Coin,
     },
     /// This is part of the rewards protocol
     Distribute {

--- a/packages/apis/src/ibc/packet.rs
+++ b/packages/apis/src/ibc/packet.rs
@@ -112,6 +112,8 @@ pub enum ConsumerPacket {
         /// This has precedence over all other events in the same packet.
         slashed: Vec<ValidatorSlashInfo>,
     },
+    /// This is a part of zero max cap process
+    /// The consumer chain will send this packet to provider, force user to unbond token
     InternalUnstake {
         delegator: String,
         validator: String,

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -54,7 +54,7 @@ pub trait VirtualStakingApi {
     ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// TODO: docs for this function
-    /// 
+    ///
     #[sv::msg(exec)]
     fn internal_unbond(
         &self,

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -53,8 +53,9 @@ pub trait VirtualStakingApi {
         amount: Coin,
     ) -> Result<Response<Self::ExecC>, Self::Error>;
 
-    /// TODO: docs for this function
-    ///
+    /// Immediately unbond the given amount due to zero max cap
+    /// When the consumer chain receives ack packet from provider - which means the unbond process from provider is success,
+    /// consumer chain will trigger this function to unbond this contract actor staking base on the delegate amount.
     #[sv::msg(exec)]
     fn internal_unbond(
         &self,

--- a/packages/apis/src/virtual_staking_api.rs
+++ b/packages/apis/src/virtual_staking_api.rs
@@ -25,6 +25,7 @@ pub trait VirtualStakingApi {
     fn bond(
         &self,
         ctx: ExecCtx<Self::QueryC>,
+        delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<Self::ExecC>, Self::Error>;
@@ -36,6 +37,7 @@ pub trait VirtualStakingApi {
     fn unbond(
         &self,
         ctx: ExecCtx<Self::QueryC>,
+        delegator: String,
         validator: String,
         amount: Coin,
     ) -> Result<Response<Self::ExecC>, Self::Error>;
@@ -48,6 +50,17 @@ pub trait VirtualStakingApi {
         &self,
         ctx: ExecCtx<Self::QueryC>,
         validators: Vec<String>,
+        amount: Coin,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
+
+    /// TODO: docs for this function
+    /// 
+    #[sv::msg(exec)]
+    fn internal_unbond(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        delegator: String,
+        validator: String,
         amount: Coin,
     ) -> Result<Response<Self::ExecC>, Self::Error>;
 

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -30,6 +30,9 @@ pub enum VirtualStakeMsg {
     /// It will then burn those tokens from the caller's account,
     /// and update the currently minted amount.
     Unbond { amount: Coin, validator: String },
+    /// TODO: Add docs for this msg
+    /// 
+    UpdateDelegation { amount: Coin, is_deduct: bool, delegator: String, validator: String},
 }
 
 impl VirtualStakeMsg {
@@ -51,6 +54,19 @@ impl VirtualStakeMsg {
         };
         VirtualStakeMsg::Unbond {
             amount: coin,
+            validator: validator.to_string(),
+        }
+    }
+    
+    pub fn update_delegation(denom: &str, is_deduct: bool, amount: impl Into<Uint128>, delgator: &str, validator: &str) -> VirtualStakeMsg {
+        let coin = Coin {
+            amount: amount.into(),
+            denom: denom.into(),
+        };
+        VirtualStakeMsg::UpdateDelegation {
+            amount: coin,
+            is_deduct,
+            delegator: delgator.to_string(),
             validator: validator.to_string(),
         }
     }

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -39,7 +39,7 @@ pub enum VirtualStakeMsg {
         validator: String,
     },
     /// Delete all scheduled tasks after zero max cap and unbond all delegations
-    DeleteAllScheduledTasks {}
+    DeleteAllScheduledTasks {},
 }
 
 impl VirtualStakeMsg {

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -30,8 +30,8 @@ pub enum VirtualStakeMsg {
     /// It will then burn those tokens from the caller's account,
     /// and update the currently minted amount.
     Unbond { amount: Coin, validator: String },
-    /// TODO: Add docs for this msg
-    ///
+    /// After each bonding or unbond process, a msg will be sent to the chain
+    /// Consumer chain will save the data - represent each delegator's stake amount
     UpdateDelegation {
         amount: Coin,
         is_deduct: bool,

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -31,8 +31,13 @@ pub enum VirtualStakeMsg {
     /// and update the currently minted amount.
     Unbond { amount: Coin, validator: String },
     /// TODO: Add docs for this msg
-    /// 
-    UpdateDelegation { amount: Coin, is_deduct: bool, delegator: String, validator: String},
+    ///
+    UpdateDelegation {
+        amount: Coin,
+        is_deduct: bool,
+        delegator: String,
+        validator: String,
+    },
 }
 
 impl VirtualStakeMsg {
@@ -57,8 +62,14 @@ impl VirtualStakeMsg {
             validator: validator.to_string(),
         }
     }
-    
-    pub fn update_delegation(denom: &str, is_deduct: bool, amount: impl Into<Uint128>, delgator: &str, validator: &str) -> VirtualStakeMsg {
+
+    pub fn update_delegation(
+        denom: &str,
+        is_deduct: bool,
+        amount: impl Into<Uint128>,
+        delgator: &str,
+        validator: &str,
+    ) -> VirtualStakeMsg {
         let coin = Coin {
             amount: amount.into(),
             denom: denom.into(),

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -38,6 +38,8 @@ pub enum VirtualStakeMsg {
         delegator: String,
         validator: String,
     },
+    /// Delete all scheduled tasks after zero max cap and unbond all delegations
+    DeleteAllScheduledTasks {}
 }
 
 impl VirtualStakeMsg {
@@ -80,6 +82,10 @@ impl VirtualStakeMsg {
             delegator: delgator.to_string(),
             validator: validator.to_string(),
         }
+    }
+
+    pub fn delete_all_scheduled_tasks() -> VirtualStakeMsg {
+        VirtualStakeMsg::DeleteAllScheduledTasks {}
     }
 }
 

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, Uint128, CustomQuery, QuerierWrapper, QueryRequest, StdResult};
+use cosmwasm_std::{Coin, CustomQuery, QuerierWrapper, QueryRequest, StdResult, Uint128};
 
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -22,7 +22,7 @@ pub enum VirtualStakeQuery {
     #[returns(SlashRatioResponse)]
     SlashRatio {},
 
-    /// Returns a max retrieve amount of delegations for the given contract 
+    /// Returns a max retrieve amount of delegations for the given contract
     #[returns(AllDelegationsResponse)]
     AllDelegations { contract: String, max_retrieve: u16 },
 }
@@ -86,8 +86,15 @@ impl<'a> TokenQuerier<'a> {
         self.querier.query(&slash_ratio_query.into())
     }
 
-    pub fn all_delegations(&self, contract: String, max_retrieve: u16) -> StdResult<AllDelegationsResponse> {
-        let all_delegations_query = VirtualStakeQuery::AllDelegations { contract, max_retrieve };
+    pub fn all_delegations(
+        &self,
+        contract: String,
+        max_retrieve: u16,
+    ) -> StdResult<AllDelegationsResponse> {
+        let all_delegations_query = VirtualStakeQuery::AllDelegations {
+            contract,
+            max_retrieve,
+        };
         self.querier.query(&all_delegations_query.into())
     }
 }

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, CustomQuery, QuerierWrapper, QueryRequest, StdResult};
+use cosmwasm_std::{Coin, Uint128, CustomQuery, QuerierWrapper, QueryRequest, StdResult};
 
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -21,6 +21,10 @@ pub enum VirtualStakeQuery {
     /// Returns the blockchain's slashing ratios.
     #[returns(SlashRatioResponse)]
     SlashRatio {},
+
+    /// Returns a max retrieve amount of delegations for the given contract 
+    #[returns(AllDelegationsResponse)]
+    AllDelegations { contract: String, max_retrieve: u16 },
 }
 
 /// Bookkeeping info in the virtual staking sdk module
@@ -40,6 +44,18 @@ pub struct SlashRatioResponse {
     pub slash_fraction_downtime: String,
     /// Slash ratio due to double signing. Applied when a validator is permanently jailed (tombstoned).
     pub slash_fraction_double_sign: String,
+}
+
+#[cw_serde]
+pub struct AllDelegationsResponse {
+    pub delegations: Vec<Delegation>,
+}
+
+#[cw_serde]
+pub struct Delegation {
+    pub delegator: String,
+    pub validator: String,
+    pub amount: Uint128,
 }
 
 impl CustomQuery for VirtualStakeCustomQuery {}
@@ -68,5 +84,10 @@ impl<'a> TokenQuerier<'a> {
     pub fn slash_ratio(&self) -> StdResult<SlashRatioResponse> {
         let slash_ratio_query = VirtualStakeQuery::SlashRatio {};
         self.querier.query(&slash_ratio_query.into())
+    }
+
+    pub fn all_delegations(&self, contract: String, max_retrieve: u16) -> StdResult<AllDelegationsResponse> {
+        let all_delegations_query = VirtualStakeQuery::AllDelegations { contract, max_retrieve };
+        self.querier.query(&all_delegations_query.into())
     }
 }

--- a/packages/virtual-staking-mock/src/lib.rs
+++ b/packages/virtual-staking-mock/src/lib.rs
@@ -1,6 +1,9 @@
 use anyhow::Result as AnyResult;
 use cosmwasm_std::{
-    coin, testing::{MockApi, MockStorage}, to_json_binary, Addr, AllDelegationsResponse, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, QuerierWrapper, Storage, Uint128
+    coin,
+    testing::{MockApi, MockStorage},
+    to_json_binary, Addr, AllDelegationsResponse, Api, Binary, BlockInfo, CustomQuery, Empty,
+    Querier, QuerierWrapper, Storage, Uint128,
 };
 use cw_multi_test::{AppResponse, BankKeeper, Module, WasmKeeper};
 use cw_storage_plus::{Item, Map};
@@ -132,9 +135,7 @@ impl Module for VirtualStakingModule {
                     Err(anyhow::anyhow!("bonded amount exceeded"))
                 }
             }
-            mesh_bindings::VirtualStakeMsg::UpdateDelegation { .. } => {
-                Ok(AppResponse::default())
-            }
+            mesh_bindings::VirtualStakeMsg::UpdateDelegation { .. } => Ok(AppResponse::default()),
         }
     }
 
@@ -183,7 +184,7 @@ impl Module for VirtualStakingModule {
             }
             mesh_bindings::VirtualStakeQuery::AllDelegations { .. } => {
                 to_json_binary(&AllDelegationsResponse {
-                    delegations: vec![]
+                    delegations: vec![],
                 })?
             }
         };

--- a/packages/virtual-staking-mock/src/lib.rs
+++ b/packages/virtual-staking-mock/src/lib.rs
@@ -136,6 +136,9 @@ impl Module for VirtualStakingModule {
                 }
             }
             mesh_bindings::VirtualStakeMsg::UpdateDelegation { .. } => Ok(AppResponse::default()),
+            mesh_bindings::VirtualStakeMsg::DeleteAllScheduledTasks { .. } => {
+                Ok(AppResponse::default())
+            }
         }
     }
 

--- a/packages/virtual-staking-mock/src/lib.rs
+++ b/packages/virtual-staking-mock/src/lib.rs
@@ -1,9 +1,6 @@
 use anyhow::Result as AnyResult;
 use cosmwasm_std::{
-    coin,
-    testing::{MockApi, MockStorage},
-    to_json_binary, Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, QuerierWrapper,
-    Storage, Uint128,
+    coin, testing::{MockApi, MockStorage}, to_json_binary, Addr, AllDelegationsResponse, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, QuerierWrapper, Storage, Uint128
 };
 use cw_multi_test::{AppResponse, BankKeeper, Module, WasmKeeper};
 use cw_storage_plus::{Item, Map};
@@ -180,6 +177,11 @@ impl Module for VirtualStakingModule {
             }
             mesh_bindings::VirtualStakeQuery::SlashRatio {} => {
                 to_json_binary(&self.slash_ratio.load(storage)?)?
+            }
+            mesh_bindings::VirtualStakeQuery::AllDelegations { .. } => {
+                to_json_binary(&AllDelegationsResponse {
+                    delegations: vec![]
+                })?
             }
         };
 

--- a/packages/virtual-staking-mock/src/lib.rs
+++ b/packages/virtual-staking-mock/src/lib.rs
@@ -132,6 +132,9 @@ impl Module for VirtualStakingModule {
                     Err(anyhow::anyhow!("bonded amount exceeded"))
                 }
             }
+            mesh_bindings::VirtualStakeMsg::UpdateDelegation { .. } => {
+                Ok(AppResponse::default())
+            }
         }
     }
 


### PR DESCRIPTION
Close #100 
Due to virtual staking and converter contract does not have delegator info, we need to resend the msg to external staking contract.

After external staking is called via ibc, converter contract get the Ack message, if it success, a msg to virtual staking contract will be executed to unbond the given amount by delegator.