### PR TITLE
Fix spelling errors

### DIFF
--- a/docs/ibc/Serializability.md
+++ b/docs/ibc/Serializability.md
@@ -45,7 +45,7 @@ if the other fails.
 ## General Approaches
 
 In distributed systems, we need to be more careful, and go back to the general definition of
-Serialiazable systems, to determine which primitives we need to implement it. And from there
+Serializable systems, to determine which primitives we need to implement it. And from there
 determine which technique will be most effective in our system. Let's start with
 [Wikipedia (which has quite good references in computer science)](https://en.m.wikipedia.org/wiki/Serializability#View_and_conflict_serializability). (All quotes below are from this page, unless otherwise noted)
 
@@ -172,7 +172,7 @@ possibly hours in the case of timeouts.
 
 We can model this with [Two-phase locking](https://en.wikipedia.org/wiki/Two-phase_locking#Two-phase_locking_and_its_special_cases)
 , which defines a "growing phase" of acquiring locks, followed by a "shrinking phase" of releasing locks. This is done to be
-resistent to deadlock. We would do the following:
+resistant to deadlock. We would do the following:
 
 1. Start Tx on Sending Chain: Acquire all read/write locks on all data that will be touched. This is the "growing" phase of the lock.
 2. Process Packet on Receiving Chain: Acquire all read/write locks on all data, process data, release all locks. This goes from the "growing" phase to the "shrinking" phase.


### PR DESCRIPTION
Fixed:

Corrected Serialiazable to Serializable for proper spelling.
Fixed resistent to resistant for correct spelling.
Why it's useful:
These changes fix spelling errors, ensuring accuracy and improving the readability of the text.