### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/docs/ibc/Staking.md
+++ b/docs/ibc/Staking.md
@@ -259,4 +259,4 @@ do_stake();
 
 ### Error correction
 
-**TODO**: Ideas about using values in success ACKs to double check the state matches expectations and flag possible errors.
+**TODO**: Ideas about using values in success ACKs to double-check the state matches expectations and flag possible errors.

--- a/docs/provider/Provider.md
+++ b/docs/provider/Provider.md
@@ -30,7 +30,7 @@ After the Consumer side is instantiated(See [Consumer Setup](../consumer/Consume
 we need to instantiate the contracts on the Provider side.
 
 The Vault contract is instantiated with the code id of the Local Staking contract,
-and a initialization message for it which includes the code id of the Native Staking Proxy contract,
+and an initialization message for it which includes the code id of the Native Staking Proxy contract,
 and a max slashing setting for local staking.
 It also requires the local denom, which is the denom of the native staking token on the Provider chain.
 

--- a/packages/apis/src/price_feed_api.rs
+++ b/packages/apis/src/price_feed_api.rs
@@ -4,7 +4,7 @@ use sylvia::types::{QueryCtx, SudoCtx};
 use sylvia::{interface, schemars};
 
 /// This is a common interface to any price feed provider.
-/// It may be a minimal example with a single price set by an governance vote,
+/// It may be a minimal example with a single price set by a governance vote,
 /// pull data from TWAP of an on-chain DEX, get remote TWAP data via IBC,
 /// or use some off-chain oracle system.
 ///


### PR DESCRIPTION
### Summary of Changes
1. **`Staking.md`**
   - Corrected "double check" to "double-check" for grammatical accuracy.

2. **`Provider.md`**
   - Fixed typo "a initialization" to "an initialization" for correct article usage.

3. **`price_feed_api.rs`**
   - Adjusted "an governance vote" to "a governance vote" for proper grammar.
