### PR TITLE
fix `clamp_page_limit` to use .min instead of .max

### DIFF
--- a/contracts/provider/external-staking/src/contract.rs
+++ b/contracts/provider/external-staking/src/contract.rs
@@ -38,7 +38,7 @@ pub const DISTRIBUTION_POINTS_SCALE: Uint256 = Uint256::from_u128(1_000_000_000)
 
 /// Aligns pagination limit
 fn clamp_page_limit(limit: Option<u32>) -> usize {
-    limit.unwrap_or(DEFAULT_PAGE_LIMIT).max(MAX_PAGE_LIMIT) as usize
+    limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT) as usize
 }
 
 pub struct ExternalStakingContract {

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -40,7 +40,7 @@ pub const MAX_PAGE_LIMIT: u32 = 30;
 
 /// Aligns pagination limit
 fn clamp_page_limit(limit: Option<u32>) -> usize {
-    limit.unwrap_or(DEFAULT_PAGE_LIMIT).max(MAX_PAGE_LIMIT) as usize
+    limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT) as usize
 }
 
 /// Default falseness for serde

--- a/contracts/provider/vault/src/mock.rs
+++ b/contracts/provider/vault/src/mock.rs
@@ -32,7 +32,7 @@ use crate::state::{Config, Lien, LocalStaking, UserInfo};
 use crate::txs::Txs;
 
 fn clamp_page_limit(limit: Option<u32>) -> usize {
-    limit.unwrap_or(DEFAULT_PAGE_LIMIT).max(MAX_PAGE_LIMIT) as usize
+    limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT) as usize
 }
 
 fn def_false() -> bool {


### PR DESCRIPTION
### Description
Limiting the page limit to a maximum permitted value is the purpose of the helper function `clamp_page_limit` but the function always returns the value `MAX_PAGE_LIMIT` when `.max(MAX_PAGE_LIMIT)` is used. With this PR `.max` is changed to `.min` so that the page limit is the smaller of `MAX_PAGE_LIMIT` and the default limit which is the purpose of the function.


