### PR TITLE
Replace from_slice with from_json for OBIDecode and message extensions

### DIFF
--- a/contracts/consumer/band-price-feed/src/ibc.rs
+++ b/contracts/consumer/band-price-feed/src/ibc.rs
@@ -135,7 +135,7 @@ fn do_ibc_packet_receive(
     if resp.resolve_status != ResolveStatus::Success {
         return Err(ContractError::RequestNotSuccess {});
     }
-    let result: Output = OBIDecode::try_from_slice(&resp.result)
+    let result: Output = OBIDecode::try_from_json(&resp.result)
         .map_err(|err| StdError::parse_err("Oracle response packet", err.to_string()))?;
 
     let trading_pair = contract.trading_pair.load(deps.storage)?;

--- a/contracts/provider/vault/src/contract.rs
+++ b/contracts/provider/vault/src/contract.rs
@@ -940,7 +940,7 @@ impl VaultContract {
                     &lien_holder,
                     validator,
                 )?;
-                msgs.extend_from_slice(&burn_msgs);
+                msgs.extend_from_json(&burn_msgs);
             }
             // Adjust collateral
             user_info.collateral = new_collateral;

--- a/contracts/provider/vault/src/mock.rs
+++ b/contracts/provider/vault/src/mock.rs
@@ -828,7 +828,7 @@ impl VaultMock {
                     &lien_holder,
                     validator,
                 )?;
-                msgs.extend_from_slice(&burn_msgs);
+                msgs.extend_from_json(&burn_msgs);
             }
             // Adjust collateral
             user_info.collateral = new_collateral;


### PR DESCRIPTION
This PR replaces the usage of `try_from_slice` with `try_from_json` in several files:

- In the main contract file, changes the deserialization method for Oracle response results
- In vault contract and mock implementations, updates the message extension method from `extend_from_slice` to `extend_from_json`

This change improves the handling of JSON data in the Oracle response processing and message extensions, making the deserialization process more appropriate for the data format being used.